### PR TITLE
fix compiling errors when when switch llvm to LLVM version 20.0.0git

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ project(lagrad-dialect LANGUAGES CXX C)
 
 set(CMAKE_BUILD_WITH_INSTALL_NAME_DIR ON)
 
-set(CMAKE_CXX_STANDARD 14 CACHE STRING "C++ standard to conform to")
+set(CMAKE_CXX_STANDARD 17 CACHE STRING "C++ standard to conform to")
 
 find_package(MLIR REQUIRED CONFIG)
 

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,5 @@
+mkdir build
+cd build
+cmake .. -Wno-dev -DMLIR_DIR=/home/zuo/code/llvm-project/build/lib/cmake/mlir/
+cmake --build . -j4
+

--- a/include/LAGrad/Analysis.h
+++ b/include/LAGrad/Analysis.h
@@ -1,5 +1,5 @@
-#include "mlir/Dialect/Linalg/IR/LinalgOps.h"
-#include "mlir/Dialect/SCF/SCF.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/IR/Dominance.h"
 #include "mlir/Pass/AnalysisManager.h"
@@ -25,7 +25,7 @@ private:
   DenseSet<Operation *> matchingInserts;
   DenseSet<Operation *> linalgInPlaceOps;
 
-  Optional<tensor::InsertSliceOp>
+  std::optional<tensor::InsertSliceOp>
   getMatchingInsertSlice(tensor::ExtractSliceOp op,
                          const DominanceInfo &dom) const;
 };
@@ -43,10 +43,10 @@ struct LoopNest {
 
 struct SparsePropagation {
   SparsePropagation(Operation *op, AnalysisManager &am);
-  Optional<HotSparsityType> getSparsityType(Value val) const;
-  Optional<HotSparsityType> getSparsityEncoding(RankedTensorType type) const;
+  std::optional<HotSparsityType> getSparsityType(Value val) const;
+  std::optional<HotSparsityType> getSparsityEncoding(RankedTensorType type) const;
   void setIndices(Value tensor, Value indices);
-  Optional<Value> getIndices(Value tensor);
+  std::optional<Value> getIndices(Value tensor);
 
 private:
   DenseMap<Value, std::string> debug_names;
@@ -61,7 +61,7 @@ private:
 struct LoopNestAnalysis {
 public:
   LoopNestAnalysis(Operation *op);
-  Optional<LoopNest> getLoopNest(scf::ForOp op) const;
+  std::optional<LoopNest> getLoopNest(scf::ForOp op) const;
   bool isLoopNest(scf::ForOp op) const;
 
 private:

--- a/include/LAGrad/LAGradDialect.td
+++ b/include/LAGrad/LAGradDialect.td
@@ -30,7 +30,7 @@ def LAGrad_Dialect : Dialect {
 // Base LAGrad operation definition.
 //===----------------------------------------------------------------------===//
 
-class LAGrad_Op<string mnemonic, list<OpTrait> traits = []> :
+class LAGrad_Op<string mnemonic, list<Trait> traits = []> :
         Op<LAGrad_Dialect, mnemonic, traits>;
 
 #endif // LAGRAD_DIALECT

--- a/include/LAGrad/LAGradOps.h
+++ b/include/LAGrad/LAGradOps.h
@@ -9,6 +9,7 @@
 #ifndef LAGRAD_LAGRADOPS_H
 #define LAGRAD_LAGRADOPS_H
 
+#include "mlir/Bytecode/BytecodeOpInterface.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Dialect.h"
 #include "mlir/IR/OpDefinition.h"

--- a/include/LAGrad/LAGradOps.td
+++ b/include/LAGrad/LAGradOps.td
@@ -13,7 +13,7 @@ include "LAGradDialect.td"
 include "mlir/IR/SymbolInterfaces.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
 
-def LAGrad_DiffOp : LAGrad_Op<"diff", [NoSideEffect]> {
+def LAGrad_DiffOp : LAGrad_Op<"diff", [Pure]> {
     let summary = "Annotate a function for automatic differentiation via Enzyme";
     let description = [{
         The `lagrad.diff` operation annotates a function for automatic differentiation via Enzyme.
@@ -28,7 +28,7 @@ def LAGrad_DiffOp : LAGrad_Op<"diff", [NoSideEffect]> {
 }
 
 def LAGrad_GradOp : LAGrad_Op<"grad", [
-        NoSideEffect,
+        Pure,
         DeclareOpInterfaceMethods<SymbolUserOpInterface>
     ]> {
     let summary = "Reverse-mode autodiff a standard function.";
@@ -45,7 +45,7 @@ def LAGrad_GradOp : LAGrad_Op<"grad", [
 }
 
 def LAGrad_TangentOp : LAGrad_Op<"tangent", [
-        NoSideEffect,
+        Pure,
         DeclareOpInterfaceMethods<SymbolUserOpInterface>
     ]> {
     let summary = "Forward-mode autodiff a standard function.";
@@ -61,7 +61,7 @@ def LAGrad_TangentOp : LAGrad_Op<"tangent", [
     }];
 }
 
-def LAGrad_PackOp : LAGrad_Op<"pack", [NoSideEffect]> {
+def LAGrad_PackOp : LAGrad_Op<"pack", [Pure]> {
     let summary = "convert fully materialized triangular tensor to packed";
     let description = [{
         The `lagrad.pack` operation denotes a conversion from a fully materialized strictly lower triangular tensor to a packed triangular tensor.
@@ -74,7 +74,7 @@ def LAGrad_PackOp : LAGrad_Op<"pack", [NoSideEffect]> {
         $source attr-dict `:` type($source) `to` type($dest)
     }];
 
-    let verifier = [{ return ::verify(*this); }];
+    let hasVerifier = 1;
 }
 
 #endif // LAGRAD_OPS

--- a/include/LAGrad/Transforms.h
+++ b/include/LAGrad/Transforms.h
@@ -4,7 +4,7 @@
 namespace mlir {
 namespace lagrad {
 
-void populateLAGradTransforms(OwningRewritePatternList &patterns,
+void populateLAGradTransforms(RewritePatternSet &patterns,
                               MLIRContext *ctx);
 
 } // end namespace lagrad

--- a/include/LAGrad/Utils.h
+++ b/include/LAGrad/Utils.h
@@ -1,7 +1,7 @@
 #include "LAGrad/LAGradDialect.h"
-#include "mlir/Dialect/Linalg/IR/LinalgOps.h"
-#include "mlir/Dialect/SCF/SCF.h"
-#include "mlir/Dialect/StandardOps/IR/Ops.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Transforms/DialectConversion.h"
 #include <string>
 
@@ -29,20 +29,20 @@ bool isFloatOrFloatTensor(Type typ);
 
 bool isLoopParallel(scf::ForOp forOp);
 
-void DEBUGpopulateFunc(NameMap &debug_names, FuncOp funcOp);
-void analyzeDynamicShapes(LAGradContext &ctx, FuncOp funcOp,
+void DEBUGpopulateFunc(NameMap &debug_names, func::FuncOp funcOp);
+void analyzeDynamicShapes(LAGradContext &ctx, func::FuncOp funcOp,
                           OpBuilder &builder);
 
 void runBottomUpDFS(SmallVector<Value> &frontier, ValueSet &out);
 void runTopDownDFS(SmallVector<Value> &frontier, ValueSet &out);
 
-void populatePrimalCaches(LAGradContext &ctx, FuncOp primalFunc,
+void populatePrimalCaches(LAGradContext &ctx, func::FuncOp primalFunc,
                           ConversionPatternRewriter &rewriter);
 
 AffineMap getRankReduceSubviewLayout(int64_t resultRank,
                                      ConversionPatternRewriter &rewriter);
 
-void runActivityAnalysis(LAGradContext &ctx, FuncOp primalFunc,
+void runActivityAnalysis(LAGradContext &ctx, func::FuncOp primalFunc,
                          ArrayAttr gradientsOf);
 
 SmallVector<Operation *>
@@ -66,10 +66,10 @@ void eraseUnusedCalls(ModuleOp moduleOp, PatternRewriter &rewriter);
 void populateVJP(Operation *op, LAGradContext &ctx, DenseMap<Value, Value> &env,
                  ConversionPatternRewriter &rewriter);
 
-FuncOp copyFunctionDeclaration(FuncOp funcOp, llvm::StringRef funcName,
+func::FuncOp copyFunctionDeclaration(func::FuncOp funcOp, llvm::StringRef funcName,
                                OpBuilder &rewriter);
 
-FuncOp differentiateFunction(FuncOp funcOp, LAGradContext &ctx,
+func::FuncOp differentiateFunction(func::FuncOp funcOp, LAGradContext &ctx,
                              ArrayAttr gradientsOf,
                              ConversionPatternRewriter &rewriter, bool topLevel,
                              bool onehotSparse);
@@ -87,6 +87,6 @@ void reverseForOp(scf::ForOp forOp, LAGradContext &ctx, ValueRange free_operand,
                   DenseMap<Value, Value> &outer_env,
                   ConversionPatternRewriter &rewriter);
 
-Value reverseCallOp(CallOp op, LAGradContext &ctx, Value vjp_value,
+Value reverseCallOp(func::CallOp op, LAGradContext &ctx, Value vjp_value,
                     size_t op_index, ConversionPatternRewriter &rewriter);
 } // namespace mlir

--- a/lagrad-opt/lagrad-opt.cpp
+++ b/lagrad-opt/lagrad-opt.cpp
@@ -13,7 +13,7 @@
 #include "mlir/Pass/Pass.h"
 #include "mlir/Pass/PassManager.h"
 #include "mlir/Support/FileUtilities.h"
-#include "mlir/Support/MlirOptMain.h"
+#include "mlir/Tools/mlir-opt/MlirOptMain.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/InitLLVM.h"
 #include "llvm/Support/SourceMgr.h"

--- a/lib/LAGrad/ActivityAnalysis.cpp
+++ b/lib/LAGrad/ActivityAnalysis.cpp
@@ -1,7 +1,10 @@
 #include "LAGrad/Logger.h"
 #include "LAGrad/Utils.h"
-#include "mlir/Dialect/Arithmetic/IR/Arithmetic.h"
-#include "mlir/Dialect/SCF/SCF.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/Math/IR/Math.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include <algorithm>
 #include <string>
 #define VERBOSITY 0
@@ -35,9 +38,9 @@ void runTopDownDFS(SmallVector<Value> &frontier, ValueSet &out) {
           }
         } else if (auto forOp = dyn_cast_or_null<scf::ForOp>(user)) {
           // Handles where the use is an iter arg operand
-          for (auto &operand : forOp.getIterOpOperands()) {
+          for (auto &operand : forOp.getInitArgsMutable()) {
             if (operand.get() == val) {
-              frontier.push_back(forOp.getRegionIterArgForOpOperand(operand));
+              frontier.push_back(forOp.getTiedLoopResult(&operand));
             }
           }
         } else if (auto scfYield = dyn_cast_or_null<scf::YieldOp>(user)) {
@@ -64,10 +67,10 @@ void runTopDownDFS(SmallVector<Value> &frontier, ValueSet &out) {
               }
             }
           }
-        } else if (auto callOp = dyn_cast_or_null<CallOp>(user)) {
+        } else if (auto callOp = dyn_cast_or_null<func::CallOp>(user)) {
           auto moduleOp = user->getParentOfType<ModuleOp>();
           assert(moduleOp && "moduleOp was null");
-          auto callee = moduleOp.lookupSymbol<FuncOp>(callOp.calleeAttr());
+          auto callee = moduleOp.lookupSymbol<func::FuncOp>(callOp.getCalleeAttr());
           assert(callee && "callee was null");
           // This will overestimate activity in the case that a function
           // argument isn't active in the callee
@@ -97,10 +100,10 @@ void runBottomUpDFS(SmallVector<Value> &frontier, ValueSet &out) {
           out.erase(val);
           continue;
         }
-        if (auto callOp = dyn_cast_or_null<CallOp>(definingOp)) {
+        if (auto callOp = dyn_cast_or_null<func::CallOp>(definingOp)) {
           auto moduleOp = definingOp->getParentOfType<ModuleOp>();
           assert(moduleOp && "moduleOp was null");
-          auto callee = moduleOp.lookupSymbol<FuncOp>(callOp.calleeAttr());
+          auto callee = moduleOp.lookupSymbol<func::FuncOp>(callOp.getCalleeAttr());
           assert(callee && "callee was null");
           assert(callee.getBody().hasOneBlock() &&
                  "expected callee to have one block");
@@ -123,7 +126,7 @@ void runBottomUpDFS(SmallVector<Value> &frontier, ValueSet &out) {
           }
           assert(result_idx != -1 && "Result was not found");
           auto yieldOp = dyn_cast<scf::YieldOp>(
-              forOp.getLoopBody().getBlocks().front().getTerminator());
+              forOp.getBody()->getTerminator());
           frontier.push_back(yieldOp.getOperand(result_idx));
         } else if (auto ifOp = dyn_cast_or_null<scf::IfOp>(definingOp)) {
           int result_idx = -1;
@@ -152,7 +155,7 @@ void runBottomUpDFS(SmallVector<Value> &frontier, ValueSet &out) {
   }
 }
 
-void runTopDownAnalysis(LAGradContext &ctx, FuncOp primalFunc,
+void runTopDownAnalysis(LAGradContext &ctx, func::FuncOp primalFunc,
                         ArrayAttr gradientsOf, ValueSet &topDownActive) {
   SmallVector<Value> frontier;
   if (!gradientsOf) {
@@ -166,7 +169,7 @@ void runTopDownAnalysis(LAGradContext &ctx, FuncOp primalFunc,
   runTopDownDFS(frontier, topDownActive);
 }
 
-void runBottomUpAnalysis(FuncOp primalFunc, ValueSet &bottomUpActive) {
+void runBottomUpAnalysis(func::FuncOp primalFunc, ValueSet &bottomUpActive) {
   assert(primalFunc.getBody().hasOneBlock() &&
          "Expected body to have one block");
   // get the terminator and traverse bottom-up
@@ -231,38 +234,38 @@ void populateAdjointUseSets(LAGradContext &ctx, Region &region,
   for (auto &op : region.getOps()) {
     if (auto addOp = dyn_cast_or_null<arith::AddFOp>(&op)) {
       ValueSet addAdjU;
-      setUnion(addAdjU, adjU[addOp.lhs()]);
-      setUnion(addAdjU, adjU[addOp.rhs()]);
+      setUnion(addAdjU, adjU[addOp.getLhs()]);
+      setUnion(addAdjU, adjU[addOp.getRhs()]);
       adjU[addOp.getResult()] = addAdjU;
     } else if (auto subOp = dyn_cast_or_null<arith::SubFOp>(&op)) {
       ValueSet subAdjU;
-      setUnion(subAdjU, adjU[subOp.lhs()]);
-      setUnion(subAdjU, adjU[subOp.rhs()]);
+      setUnion(subAdjU, adjU[subOp.getLhs()]);
+      setUnion(subAdjU, adjU[subOp.getRhs()]);
       adjU[subOp.getResult()] = subAdjU;
     } else if (auto negOp = dyn_cast_or_null<arith::NegFOp>(&op)) {
       ValueSet negAdjU;
-      setUnion(negAdjU, adjU[negOp.operand()]);
+      setUnion(negAdjU, adjU[negOp.getOperand()]);
       adjU[negOp.getResult()] = negAdjU;
     } else if (auto mulOp = dyn_cast_or_null<arith::MulFOp>(&op)) {
       ValueSet mulAdjU;
-      if (ctx.activeValues.contains(mulOp.lhs())) {
-        mulAdjU.insert(mulOp.rhs());
-        setUnion(mulAdjU, adjU[mulOp.lhs()]);
+      if (ctx.activeValues.contains(mulOp.getLhs())) {
+        mulAdjU.insert(mulOp.getRhs());
+        setUnion(mulAdjU, adjU[mulOp.getLhs()]);
       }
-      if (ctx.activeValues.contains(mulOp.rhs())) {
-        mulAdjU.insert(mulOp.lhs());
-        setUnion(mulAdjU, adjU[mulOp.rhs()]);
+      if (ctx.activeValues.contains(mulOp.getRhs())) {
+        mulAdjU.insert(mulOp.getLhs());
+        setUnion(mulAdjU, adjU[mulOp.getRhs()]);
       }
       adjU[mulOp.getResult()] = mulAdjU;
     } else if (auto divOp = dyn_cast_or_null<arith::DivFOp>(&op)) {
       ValueSet divAdjU;
-      if (ctx.activeValues.contains(divOp.lhs())) {
-        divAdjU.insert(divOp.rhs());
-        setUnion(divAdjU, adjU[divOp.lhs()]);
+      if (ctx.activeValues.contains(divOp.getLhs())) {
+        divAdjU.insert(divOp.getRhs());
+        setUnion(divAdjU, adjU[divOp.getLhs()]);
       }
-      if (ctx.activeValues.contains(divOp.rhs())) {
-        divAdjU.insert(divOp.lhs());
-        setUnion(divAdjU, adjU[divOp.rhs()]);
+      if (ctx.activeValues.contains(divOp.getRhs())) {
+        divAdjU.insert(divOp.getLhs());
+        setUnion(divAdjU, adjU[divOp.getRhs()]);
       }
       adjU[divOp.getResult()] = divAdjU;
     } else if (auto logOp = dyn_cast_or_null<math::LogOp>(&op)) {
@@ -282,9 +285,9 @@ void populateAdjointUseSets(LAGradContext &ctx, Region &region,
       tanhAdjU.insert(tanhOp.getOperand());
       setUnion(tanhAdjU, adjU[tanhOp.getOperand()]);
       adjU[tanhOp.getResult()] = tanhAdjU;
-    } else if (auto selectOp = dyn_cast<SelectOp>(&op)) {
+    } else if (auto selectOp = dyn_cast<arith::SelectOp>(&op)) {
       ValueSet selectAdjU;
-      selectAdjU.insert(selectOp.condition());
+      selectAdjU.insert(selectOp.getCondition());
       adjU[selectOp.getResult()] = selectAdjU;
     } else if (auto genericOp = dyn_cast_or_null<linalg::GenericOp>(&op)) {
       ValueSet genericAdjU;
@@ -298,8 +301,8 @@ void populateAdjointUseSets(LAGradContext &ctx, Region &region,
           }
         }
 
-        SmallVector<Value> frontier{adjU[yieldOperand].begin(),
-                                    adjU[yieldOperand].end()};
+        SmallVector<Value> frontier;
+        frontier.append(adjU[yieldOperand].begin(), adjU[yieldOperand].end());
         ValueSet yieldDeps;
         runBottomUpDFS(frontier, yieldDeps);
         for (auto tup : llvm::zip(genericOp.getOperands(),
@@ -320,10 +323,10 @@ void populateAdjointUseSets(LAGradContext &ctx, Region &region,
                op.getName().getStringRef() == "linalg.batch_matmul") {
       ValueSet linalgAdjU;
       auto linalgOp = cast<linalg::LinalgOp>(&op);
-      assert(linalgOp.getNumInputs() == 2 &&
+      assert(linalgOp.getNumDpsInputs() == 2 &&
              "Expected named linalg op to have 2 inputs");
-      auto lhs = linalgOp.getInputOperand(0)->get();
-      auto rhs = linalgOp.getInputOperand(1)->get();
+      auto lhs = linalgOp.getDpsInputOperand(0)->get();
+      auto rhs = linalgOp.getDpsInputOperand(1)->get();
       if (ctx.activeValues.contains(lhs)) {
         linalgAdjU.insert(rhs);
         setUnion(linalgAdjU, adjU[lhs]);
@@ -335,17 +338,17 @@ void populateAdjointUseSets(LAGradContext &ctx, Region &region,
       adjU[linalgOp->getResult(0)] = linalgAdjU;
     } else if (auto extractOp = dyn_cast_or_null<tensor::ExtractOp>(&op)) {
       ValueSet extractAdjU;
-      setUnion(extractAdjU, adjU[extractOp.tensor()]);
-      for (auto idx : extractOp.indices()) {
+      setUnion(extractAdjU, adjU[extractOp.getTensor()]);
+      for (auto idx : extractOp.getIndices()) {
         extractAdjU.insert(idx);
       }
       adjU[extractOp.getResult()] = extractAdjU;
     } else if (auto insertOp = dyn_cast_or_null<tensor::InsertOp>(&op)) {
-      if (ctx.activeValues.contains(insertOp.scalar())) {
+      if (ctx.activeValues.contains(insertOp.getScalar())) {
         ValueSet insertAdjU;
-        setUnion(insertAdjU, adjU[insertOp.scalar()]);
-        setUnion(insertAdjU, adjU[insertOp.dest()]);
-        for (auto idx : insertOp.indices()) {
+        setUnion(insertAdjU, adjU[insertOp.getScalar()]);
+        setUnion(insertAdjU, adjU[insertOp.getDest()]);
+        for (auto idx : insertOp.getIndices()) {
           insertAdjU.insert(idx);
         }
         adjU[insertOp.getResult()] = insertAdjU;
@@ -353,21 +356,21 @@ void populateAdjointUseSets(LAGradContext &ctx, Region &region,
     } else if (auto extractSliceOp =
                    dyn_cast_or_null<tensor::ExtractSliceOp>(&op)) {
       ValueSet extractSliceAdjU;
-      setUnion(extractSliceAdjU, adjU[extractSliceOp.source()]);
+      setUnion(extractSliceAdjU, adjU[extractSliceOp.getSource()]);
       for (auto offs : extractSliceOp.getMixedOffsets()) {
-        if (auto val = offs.dyn_cast<Value>()) {
+        if (auto val = dyn_cast_if_present<Value>(offs)) {
           extractSliceAdjU.insert(val);
         }
       }
       adjU[extractSliceOp.getResult()] = extractSliceAdjU;
     } else if (auto insertSliceOp =
                    dyn_cast_or_null<tensor::InsertSliceOp>(&op)) {
-      if (ctx.activeValues.contains(insertSliceOp.source())) {
+      if (ctx.activeValues.contains(insertSliceOp.getSource())) {
         ValueSet insertSliceAdjU;
-        setUnion(insertSliceAdjU, adjU[insertSliceOp.source()]);
-        setUnion(insertSliceAdjU, adjU[insertSliceOp.dest()]);
+        setUnion(insertSliceAdjU, adjU[insertSliceOp.getSource()]);
+        setUnion(insertSliceAdjU, adjU[insertSliceOp.getDest()]);
         for (auto offs : insertSliceOp.getMixedOffsets()) {
-          if (auto val = offs.dyn_cast<Value>()) {
+          if (auto val = dyn_cast_if_present<Value>(offs)) {
             insertSliceAdjU.insert(val);
           }
         }
@@ -376,8 +379,8 @@ void populateAdjointUseSets(LAGradContext &ctx, Region &region,
     } else if (auto ifOp = dyn_cast_or_null<scf::IfOp>(&op)) {
       if (ifOp.getNumResults() > 0) {
         ValueSet ifAdjU;
-        populateAdjointUseSets(ctx, ifOp.thenRegion(), adjU);
-        populateAdjointUseSets(ctx, ifOp.elseRegion(), adjU);
+        populateAdjointUseSets(ctx, ifOp.getThenRegion(), adjU);
+        populateAdjointUseSets(ctx, ifOp.getElseRegion(), adjU);
         for (auto operand : ifOp.thenBlock()->getTerminator()->getOperands()) {
           setUnion(ifAdjU, adjU[operand]);
         }
@@ -399,16 +402,16 @@ void populateAdjointUseSets(LAGradContext &ctx, Region &region,
       for (auto result : forOp.getResults()) {
         adjU[result] = forAdjU;
       }
-    } else if (auto callOp = dyn_cast_or_null<CallOp>(&op)) {
+    } else if (auto callOp = dyn_cast_or_null<func::CallOp>(&op)) {
       ValueSet callAdjU;
       auto &callRegion =
-          ctx.moduleOp.lookupSymbol<FuncOp>(callOp.calleeAttr()).getBody();
+          ctx.moduleOp.lookupSymbol<func::FuncOp>(callOp.getCalleeAttr()).getBody();
       populateAdjointUseSets(ctx, callRegion, adjU);
       if (callRegion.hasOneBlock()) {
         for (auto returnOperand :
              callRegion.back().getTerminator()->getOperands()) {
-          SmallVector<Value> frontier{adjU[returnOperand].begin(),
-                                      adjU[returnOperand].end()};
+          SmallVector<Value> frontier;
+          frontier.append(adjU[returnOperand].begin(), adjU[returnOperand].end());
           ValueSet returnDeps;
           runBottomUpDFS(frontier, returnDeps);
           for (auto tup :
@@ -427,7 +430,7 @@ void populateAdjointUseSets(LAGradContext &ctx, Region &region,
   }
 }
 
-void runEffectiveUseAnalysis(LAGradContext &ctx, FuncOp primalFunc) {
+void runEffectiveUseAnalysis(LAGradContext &ctx, func::FuncOp primalFunc) {
   // adjU maps results to sets of effectively used values
   if (VERBOSITY >= 1) {
     llvm::errs() << "Running TBR Analysis for func " << primalFunc.getName()
@@ -440,12 +443,12 @@ void runEffectiveUseAnalysis(LAGradContext &ctx, FuncOp primalFunc) {
         llvm::errs() << BOLDCYAN << "Running Effective-Use Analysis for loop "
                      << ctx.debug_names[forOp.getResult(0)] << RESET << "\n";
       }
-      populateAdjointUseSets(ctx, forOp.getLoopBody(), adjU);
+      populateAdjointUseSets(ctx, forOp.getBodyRegion(), adjU);
       if (VERBOSITY >= 3) {
         printAllAdjU(ctx, adjU);
       }
       for (auto operand :
-           forOp.getLoopBody().front().getTerminator()->getOperands()) {
+           forOp.getBody()->getTerminator()->getOperands()) {
         setUnion(ctx.effectivelyUsed, adjU[operand]);
       }
 
@@ -500,7 +503,7 @@ void runEffectiveUseAnalysis(LAGradContext &ctx, FuncOp primalFunc) {
 }
 } // namespace mlir
 
-void mlir::runActivityAnalysis(LAGradContext &ctx, FuncOp primalFunc,
+void mlir::runActivityAnalysis(LAGradContext &ctx, func::FuncOp primalFunc,
                                ArrayAttr gradientsOf) {
   llvm::SmallDenseSet<Value> topDownActive;
   llvm::SmallDenseSet<Value> bottomUpActive;

--- a/lib/LAGrad/Bufferize.cpp
+++ b/lib/LAGrad/Bufferize.cpp
@@ -2,17 +2,17 @@
  * A custom pass meant to fill gaps in bufferizing tensor ops.
  * Motivated by a lack of bufferization for the tensor.insert op.
  */
-#include "mlir/Transforms/Bufferize.h"
+#include "mlir/Dialect/Bufferization/Transforms/Bufferize.h"
+#include "mlir/Dialect/Bufferization/IR/Bufferization.h"
 #include "LAGrad/Analysis.h"
 #include "LAGrad/Logger.h"
 #include "LAGrad/Passes.h"
 #include "LAGrad/Utils.h"
-#include "mlir/Dialect/Arithmetic/IR/Arithmetic.h"
-#include "mlir/Dialect/Linalg/IR/LinalgOps.h"
-#include "mlir/Dialect/Linalg/Transforms/ComprehensiveBufferize.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
-#include "mlir/Dialect/SCF/SCF.h"
-#include "mlir/Dialect/StandardOps/IR/Ops.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/Dialect/Tensor/Transforms/Passes.h"
 #include "mlir/Transforms/DialectConversion.h"
@@ -25,29 +25,43 @@ using llvm::errs;
 constexpr bool force_copy = false;
 
 namespace {
+class BufferizeTypeConverter : public TypeConverter {
+public:
+  BufferizeTypeConverter() {
+    addConversion([](Type type) { return type; });
+    addConversion([](RankedTensorType type) -> Type {
+      return MemRefType::get(type.getShape(), type.getElementType());
+    });
+  }
+};
+} // namespace
+
+namespace {
 
 void bufferizeLinalgOp(linalg::LinalgOp linalgOp, ValueRange outputBuffers,
-                       ValueRange results, TypeConverter &typeConverter,
+                       ValueRange results, const TypeConverter &typeConverter,
                        ConversionPatternRewriter &rewriter) {
   PatternRewriter::InsertionGuard g(rewriter);
   rewriter.setInsertionPoint(linalgOp);
 
   SmallVector<Value> newOperands;
-  newOperands.reserve(linalgOp.getNumInputsAndOutputs());
-  for (OpOperand *inputOperand : linalgOp.getInputTensorOperands()) {
-    newOperands.push_back(rewriter.create<memref::BufferCastOp>(
+  newOperands.reserve(linalgOp.getNumDpsInputs() + linalgOp.getNumDpsInits());
+  for (OpOperand *inputOperand : linalgOp.getDpsInputOperands()) {
+    newOperands.push_back(rewriter.create<bufferization::ToMemrefOp>(
         linalgOp.getLoc(),
-        typeConverter.convertType(inputOperand->get().getType()),
+        typeConverter.convertType(inputOperand->get().getType()).cast<MemRefType>(),
         inputOperand->get()));
   }
   newOperands.append(outputBuffers.begin(), outputBuffers.end());
 
   assert(linalgOp->getNumRegions() == 1 &&
          "expected linalg op to have 1 region");
-  auto newOp = cast<linalg::LinalgOp>(linalgOp.cloneWithoutRegions(
-      rewriter, linalgOp.getLoc(), TypeRange{}, newOperands));
-  rewriter.inlineRegionBefore(linalgOp->getRegion(0), newOp->getRegion(0),
-                              newOp->getRegion(0).begin());
+  OperationState state(linalgOp.getLoc(), linalgOp->getName());
+  state.addOperands(newOperands);
+  state.addTypes(TypeRange{});
+  state.addAttributes(linalgOp->getAttrs());
+  auto newOp = cast<linalg::LinalgOp>(rewriter.create(state));
+  newOp->getRegion(0).takeBody(linalgOp->getRegion(0));
 
   // The number of output buffers should always be 1 for now.
   rewriter.replaceOp(linalgOp, results);
@@ -76,30 +90,30 @@ public:
                           ->convertType(extractSliceOp.getSourceType())
                           .cast<MemRefType>();
 
-    auto resultType = eraseStridedLayout(
+    auto resultType =
         memref::SubViewOp::inferRankReducedResultType(
             sliceType.getRank(), sourceType, extractSliceOp.getMixedOffsets(),
             extractSliceOp.getMixedSizes(), extractSliceOp.getMixedStrides())
-            .cast<MemRefType>());
+            .cast<MemRefType>();
     auto identityResultType =
         getTypeConverter()->convertType(sliceType).cast<MemRefType>();
-    auto source = rewriter.create<memref::BufferCastOp>(
-        op->getLoc(), sourceType, extractSliceOp.source());
+    auto source = rewriter.create<bufferization::ToMemrefOp>(
+        op->getLoc(), sourceType, extractSliceOp.getSource());
     auto subview = rewriter.create<memref::SubViewOp>(
         op->getLoc(), resultType, source, extractSliceOp.getMixedOffsets(),
         extractSliceOp.getMixedSizes(), extractSliceOp.getMixedStrides());
     auto casted = rewriter.create<memref::CastOp>(
-        op->getLoc(), subview.getResult(), identityResultType);
-    auto loaded = rewriter.create<memref::TensorLoadOp>(op->getLoc(), casted);
+        op->getLoc(), identityResultType, subview.getResult());
+    auto loaded = rewriter.create<bufferization::ToTensorOp>(op->getLoc(), casted);
     rewriter.replaceOp(op, loaded.getResult());
-    rewriter.replaceOp(insertSliceOp, extractSliceOp.source());
+    rewriter.replaceOp(insertSliceOp, extractSliceOp.getSource());
 
     // Need to ensure linalg ops that write to the extractSliceOp are bufferized
     // in-place.
     for (auto &use : extractSliceOp.getResult().getUses()) {
       if (ieAnalysis.isLinalgMarkedForBufferization(use.getOwner())) {
         auto linalgOp = dyn_cast<linalg::LinalgOp>(use.getOwner());
-        if (linalgOp.isOutputTensor(&use)) {
+        if (linalgOp.isInitTensor(&use)) {
           bufferizeLinalgOp(linalgOp, /*outputBuffers=*/subview.getResult(),
                             /*results=*/loaded.getResult(), *getTypeConverter(),
                             rewriter);
@@ -131,15 +145,16 @@ public:
       : OpConversionPattern(typeConverter, ctx, /*benefit=*/1) {}
 
   LogicalResult
-  matchAndRewrite(linalg::FillOp op, ArrayRef<Value> operands,
+  matchAndRewrite(linalg::FillOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     if (op.getNumResults() != 1) {
       return failure();
     }
 
-    bool mustCopy = !hasUseAfter(op.output(), op.getResult(0));
+    Value outputVal = op.getDpsInitOperand(0)->get();
+    bool mustCopy = !hasUseAfter(outputVal, op.getResult(0));
     if (mustCopy) {
-      auto outputType = op.output().getType().cast<ShapedType>();
+      auto outputType = outputVal.getType().cast<ShapedType>();
       if (!outputType.hasStaticShape()) {
         return failure();
       }
@@ -154,13 +169,13 @@ public:
 
       Value copy = rewriter.create<memref::AllocOp>(
           op.getLoc(), getTypeConverter()
-                           ->convertType(op.output().getType())
+                           ->convertType(outputVal.getType())
                            .cast<MemRefType>());
-      rewriter.create<linalg::FillOp>(op.getLoc(), op.value(), copy);
+      rewriter.create<linalg::FillOp>(op.getLoc(), adaptor.getInputs()[0], copy);
       rewriter.replaceOp(op, copy);
     } else {
-      rewriter.create<linalg::FillOp>(op.getLoc(), operands[0], operands[1]);
-      rewriter.replaceOp(op, operands[1]);
+      rewriter.create<linalg::FillOp>(op.getLoc(), adaptor.getInputs()[0], adaptor.getOutputs()[0]);
+      rewriter.replaceOp(op, adaptor.getOutputs()[0]);
     }
     return success();
   }
@@ -172,13 +187,13 @@ public:
   LogicalResult
   matchAndRewrite(tensor::InsertOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    memref::TensorLoadOp loaded;
+    bufferization::ToTensorOp loaded;
 
     // This is very naïve.
     DominanceInfo dom;
     bool hasUseAfter = false;
 
-    for (auto user : op.dest().getUsers()) {
+    for (auto user : op.getDest().getUsers()) {
       if (dom.properlyDominates(op.getResult(), user)) {
         hasUseAfter = true;
       }
@@ -188,17 +203,17 @@ public:
     if (!hasUseAfter && !force_copy) {
       // This first implementation updates the tensor in place rather than
       // returning a copy per the spec. Watch out for bugs this may cause.
-      rewriter.create<memref::StoreOp>(op.getLoc(), adaptor.scalar(),
-                                       adaptor.dest(), adaptor.indices());
+      rewriter.create<memref::StoreOp>(op.getLoc(), adaptor.getScalar(),
+                                       adaptor.getDest(), adaptor.getIndices());
       loaded =
-          rewriter.create<memref::TensorLoadOp>(op.getLoc(), adaptor.dest());
+          rewriter.create<bufferization::ToTensorOp>(op.getLoc(), adaptor.getDest());
     } else {
       auto space = rewriter.create<memref::AllocOp>(
-          op.getLoc(), adaptor.dest().getType().cast<MemRefType>());
-      rewriter.create<linalg::CopyOp>(op.getLoc(), adaptor.dest(), space);
-      rewriter.create<memref::StoreOp>(op.getLoc(), adaptor.scalar(), space,
-                                       adaptor.indices());
-      loaded = rewriter.create<memref::TensorLoadOp>(op.getLoc(), space);
+          op.getLoc(), adaptor.getDest().getType().cast<MemRefType>());
+      rewriter.create<linalg::CopyOp>(op.getLoc(), ValueRange{adaptor.getDest()}, ValueRange{space});
+      rewriter.create<memref::StoreOp>(op.getLoc(), adaptor.getScalar(), space,
+                                       adaptor.getIndices());
+      loaded = rewriter.create<bufferization::ToTensorOp>(op.getLoc(), space);
     }
 
     op.replaceAllUsesWith(loaded.getResult());
@@ -238,22 +253,22 @@ public:
         op.getOffsetSizeAndStrideStartOperandIndex() != 1) {
       return failure();
     }
-    auto sourceType = adaptor.source().getType().cast<MemRefType>();
-    Value source = adaptor.source();
+    auto sourceType = adaptor.getSource().getType().cast<MemRefType>();
+    Value source = adaptor.getSource();
     // Ugly, brittle hack to get extract_slice with compressed GMMs working.
     // This results in the source having a fully dynamic layout map, which is
     // okay, but partial bufferization appears to expect an identity layout
     // map at the end of this transformation.
     if (sourceType.getDimSize(sourceType.getRank() - 1) == 1) {
       source = rewriter.create<memref::CastOp>(
-          op.getLoc(), eraseStridedLayout(sourceType), source);
+          op.getLoc(), sourceType, source);
     }
 
     auto resultType =
-        eraseStridedLayout(memref::SubViewOp::inferRankReducedResultType(
-                               resultRank, sourceType, op.getMixedOffsets(),
-                               op.getMixedSizes(), op.getMixedStrides())
-                               .cast<MemRefType>());
+        memref::SubViewOp::inferRankReducedResultType(
+            resultRank, sourceType, op.getMixedOffsets(),
+            op.getMixedSizes(), op.getMixedStrides())
+            .cast<MemRefType>();
     auto identityResultType =
         getTypeConverter()->convertType(resultTensorType).cast<MemRefType>();
 
@@ -264,7 +279,7 @@ public:
     DominanceInfo dom;
     bool hasWriteAfter = false;
 
-    for (auto user : op.source().getUsers()) {
+    for (auto user : op.getSource().getUsers()) {
       if (dom.properlyDominates(op.getResult(), user)) {
         hasWriteAfter = true;
       }
@@ -274,7 +289,7 @@ public:
     // This causes a slow-down with GMM/main term, have yet to look into why.
 
     // This is a coarse-grained heuristic.
-    // SmallVector<Value> frontier{op.source()};
+    // SmallVector<Value> frontier{op.getSource()};
     // ValueSet derivedFromSource;
     // runTopDownDFS(frontier, derivedFromSource);
     // for (Value derivedValue : derivedFromSource) {
@@ -286,14 +301,14 @@ public:
     //   }
     // }
     if (!hasWriteAfter && !force_copy) {
-      // rewriter.replaceOpWithNewOp<memref::TensorLoadOp>(op,
+      // rewriter.replaceOpWithNewOp<bufferization::ToTensorOp>(op,
       //                                                   subview.getResult());
-      rewriter.replaceOpWithNewOp<memref::CastOp>(op, subview.getResult(),
-                                                  identityResultType);
+      rewriter.replaceOpWithNewOp<memref::CastOp>(op, identityResultType,
+                                                  subview.getResult());
     } else {
       auto dest =
           rewriter.create<memref::AllocOp>(op.getLoc(), identityResultType);
-      rewriter.create<linalg::CopyOp>(op.getLoc(), subview, dest);
+      rewriter.create<linalg::CopyOp>(op.getLoc(), ValueRange{subview.getResult()}, ValueRange{dest});
       rewriter.replaceOp(op, dest.getResult());
     }
     return success();
@@ -323,7 +338,7 @@ public:
     DominanceInfo dom;
     bool hasUseAfter = false;
 
-    for (auto user : op.dest().getUsers()) {
+    for (auto user : op.getDest().getUsers()) {
       if (dom.properlyDominates(op.getResult(), user)) {
         hasUseAfter = true;
       }
@@ -332,24 +347,24 @@ public:
     auto sliceType =
         memref::SubViewOp::inferRankReducedResultType(
             op.getSourceType().getRank(),
-            adaptor.dest().getType().cast<MemRefType>(), op.getMixedOffsets(),
+            adaptor.getDest().getType().cast<MemRefType>(), op.getMixedOffsets(),
             op.getMixedSizes(), op.getMixedStrides())
             .cast<MemRefType>();
     if (!hasUseAfter) {
       auto subview = rewriter.create<memref::SubViewOp>(
-          op.getLoc(), sliceType, adaptor.dest(), op.getMixedOffsets(),
+          op.getLoc(), sliceType, adaptor.getDest(), op.getMixedOffsets(),
           op.getMixedSizes(), op.getMixedStrides());
-      rewriter.create<linalg::CopyOp>(op.getLoc(), adaptor.source(), subview);
-      rewriter.replaceOp(op, adaptor.dest());
+      rewriter.create<linalg::CopyOp>(op.getLoc(), ValueRange{adaptor.getSource()}, ValueRange{subview.getResult()});
+      rewriter.replaceOp(op, adaptor.getDest());
     } else {
       auto dest = rewriter.create<memref::AllocOp>(
-          op.getLoc(), adaptor.dest().getType().dyn_cast<MemRefType>());
-      rewriter.create<linalg::CopyOp>(op.getLoc(), adaptor.dest(), dest);
+          op.getLoc(), adaptor.getDest().getType().dyn_cast<MemRefType>());
+      rewriter.create<linalg::CopyOp>(op.getLoc(), ValueRange{adaptor.getDest()}, ValueRange{dest});
       auto subview = rewriter.create<memref::SubViewOp>(
           op.getLoc(), sliceType, dest, op.getMixedOffsets(),
           op.getMixedSizes(), op.getMixedStrides());
 
-      rewriter.create<linalg::CopyOp>(op.getLoc(), adaptor.source(), subview);
+      rewriter.create<linalg::CopyOp>(op.getLoc(), ValueRange{adaptor.getSource()}, ValueRange{subview.getResult()});
       rewriter.replaceOp(op, dest.getResult());
     }
     return success();
@@ -363,23 +378,23 @@ public:
   LogicalResult
   matchAndRewrite(linalg::LinalgOp op, ArrayRef<Value> operands,
                   ConversionPatternRewriter &rewriter) const override {
-    if (op.hasBufferSemantics()) {
+    if (op.hasPureBufferSemantics()) {
       return failure();
     }
     DominanceInfo dom;
     bool hasUseAfter = false;
-    for (auto user : op.getOutputOperand(0)->get().getUsers()) {
+    for (auto user : op.getDpsInitOperand(0)->get().getUsers()) {
       if (dom.properlyDominates(op->getResult(0), user)) {
         hasUseAfter = true;
       }
     }
     SmallVector<Value> newOperands{operands.begin(), operands.end()};
     Operation *parentOp =
-        op.getOutputOperand(0)->get().getDefiningOp()
-            ?: op.getOutputOperand(0)->get().getParentRegion()->getParentOp();
+        op.getDpsInitOperand(0)->get().getDefiningOp()
+            ?: op.getDpsInitOperand(0)->get().getParentRegion()->getParentOp();
     bool isImmutableArg = false;
-    if (auto funcOp = dyn_cast<FuncOp>(parentOp)) {
-      auto blockArg = op.getOutputOperand(0)->get().cast<BlockArgument>();
+    if (auto funcOp = dyn_cast<func::FuncOp>(parentOp)) {
+      auto blockArg = op.getDpsInitOperand(0)->get().cast<BlockArgument>();
       // Function arguments are immutable by default.
       isImmutableArg = !static_cast<bool>(
           funcOp.getArgAttr(blockArg.getArgNumber(), "linalg.mutable"));
@@ -387,15 +402,15 @@ public:
     bool isConstantMemory = isa_and_nonnull<arith::ConstantOp>(parentOp);
     bool mustCopy = hasUseAfter || isConstantMemory || isImmutableArg;
 
-    assert(op.getNumOutputs() == 1);
+    assert(op.getNumDpsInits() == 1);
     if (mustCopy) {
       errs() << "Analysis determined we must copy: hasUseAfter " << hasUseAfter
              << " isConstantMemory: " << isConstantMemory
              << " isImmutableArg: " << isImmutableArg << "\n";
       auto space = rewriter.create<memref::AllocOp>(
           op.getLoc(), newOperands.back().getType().cast<MemRefType>());
-      rewriter.create<linalg::CopyOp>(op.getLoc(), newOperands.back(), space);
-      newOperands[newOperands.size() - 1] = space;
+      rewriter.create<linalg::CopyOp>(op.getLoc(), ValueRange{newOperands.back()}, ValueRange{space.getResult()});
+      newOperands[newOperands.size() - 1] = space.getResult();
     } else {
       op.emitRemark() << "Made in-place update";
     }
@@ -404,13 +419,15 @@ public:
     Operation *unknownOp = op;
     auto linalgOp = cast<linalg::LinalgOp>(unknownOp);
     assert(op->getNumRegions() == 1 && "expected linalg op to have 1 region");
-    auto newOp = cast<linalg::LinalgOp>(linalgOp.cloneWithoutRegions(
-        rewriter, op.getLoc(), TypeRange{}, newOperands));
-    rewriter.inlineRegionBefore(op->getRegion(0), newOp->getRegion(0),
-                                newOp->getRegion(0).begin());
-    for (auto outputBuffer : newOp.getOutputBufferOperands()) {
-      results.push_back(rewriter.create<memref::TensorLoadOp>(
-          op.getLoc(), outputBuffer->get()));
+    OperationState state(op.getLoc(), op->getName());
+    state.addOperands(newOperands);
+    state.addTypes(TypeRange{});
+    state.addAttributes(op->getAttrs());
+    auto newOp = cast<linalg::LinalgOp>(rewriter.create(state));
+    newOp->getRegion(0).takeBody(op->getRegion(0));
+    for (int64_t i = 0, e = newOp.getNumDpsInits(); i < e; ++i) {
+      results.push_back(rewriter.create<bufferization::ToTensorOp>(
+          op.getLoc(), newOp.getDpsInitOperand(i)->get()));
     }
 
     rewriter.replaceOp(op, results);
@@ -455,8 +472,8 @@ struct StandaloneBufferizePass : public OperationPass<ModuleOp> {
       ieAnalysis.disableAnalysis();
 
     target.addLegalDialect<memref::MemRefDialect>();
-    target.addDynamicallyLegalDialect<arith::ArithmeticDialect,
-                                      StandardOpsDialect>([&](Operation *op) {
+    target.addDynamicallyLegalDialect<arith::ArithDialect,
+                                      func::FuncDialect>([&](Operation *op) {
       return typeConverter.isLegal(op) || isa<arith::ConstantOp>(op);
     });
     target.addDynamicallyLegalDialect<linalg::LinalgDialect>(
@@ -465,17 +482,17 @@ struct StandaloneBufferizePass : public OperationPass<ModuleOp> {
                  !ieAnalysis.isLinalgMarkedForBufferization(op);
         });
     target.addDynamicallyLegalOp<linalg::FillOp>([](linalg::FillOp op) {
-      return op.hasBufferSemantics() || op.getNumResults() != 1 ||
-             !op.output().getType().cast<ShapedType>().hasStaticShape();
+      return op.hasPureBufferSemantics() || op.getNumResults() != 1 ||
+             !op.getDpsInitOperand(0)->get().getType().cast<ShapedType>().hasStaticShape();
     });
-    target.addLegalOp<CallOp>();
-    target.addLegalOp<ReturnOp>();
+    target.addLegalOp<func::CallOp>();
+    target.addLegalOp<func::ReturnOp>();
     target.addLegalOp<linalg::CopyOp>();
     target.addLegalOp<linalg::YieldOp>();
-    target.addLegalOp<linalg::InitTensorOp>();
+    target.addLegalOp<tensor::EmptyOp>();
     target.addIllegalOp<tensor::InsertOp>();
     target.addLegalDialect<scf::SCFDialect>();
-    populateBufferizeMaterializationLegality(target);
+    target.addLegalDialect<bufferization::BufferizationDialect>();
 
     patterns.add<BufferizeInsertOp>(typeConverter, patterns.getContext());
     patterns.add<BufferizeInsertExtractPair>(ieAnalysis, typeConverter,

--- a/lib/LAGrad/DeadCodeElimination.cpp
+++ b/lib/LAGrad/DeadCodeElimination.cpp
@@ -4,14 +4,15 @@
  */
 #include "LAGrad/Passes.h"
 #include "LAGrad/Utils.h"
-#include "mlir/Dialect/Arithmetic/IR/Arithmetic.h"
-#include "mlir/Dialect/Linalg/IR/LinalgOps.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
-#include "mlir/Dialect/SCF/SCF.h"
-#include "mlir/Dialect/StandardOps/IR/Ops.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/Dialect/Tensor/Transforms/Passes.h"
-#include "mlir/Transforms/Bufferize.h"
+#include "mlir/Dialect/Bufferization/IR/Bufferization.h"
+#include "mlir/Dialect/Bufferization/Transforms/Bufferize.h"
 #include "mlir/Transforms/DialectConversion.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "mlir/Transforms/Passes.h"
@@ -46,7 +47,7 @@ void BFS(ValueRange start, llvm::SmallDenseSet<Value> &liveValues) {
 void populateLiveBodyArgs(scf::ForOp forOp,
                           llvm::SmallDenseSet<Value> &liveValues) {
   auto yieldOp = cast<scf::YieldOp>(forOp.getBody()->getTerminator());
-  for (auto it : llvm::zip(yieldOp.results(), forOp.getResults(),
+  for (auto it : llvm::zip(yieldOp.getOperands(), forOp.getResults(),
                            forOp.getRegionIterArgs())) {
     auto yieldResult = std::get<0>(it);
     auto result = std::get<1>(it);
@@ -54,11 +55,12 @@ void populateLiveBodyArgs(scf::ForOp forOp,
     if (!result.use_empty()) {
       BFS(yieldResult, liveValues);
     } else {
-      SmallVector<Value> frontier{iterArg};
+      SmallVector<Value> frontier;
+      frontier.push_back(iterArg);
       ValueSet derivedFromIterArg;
       runTopDownDFS(frontier, derivedFromIterArg);
       for (auto derived : derivedFromIterArg) {
-        if (dyn_cast_or_null<memref::BufferCastOp>(derived.getDefiningOp())) {
+        if (dyn_cast_or_null<bufferization::ToMemrefOp>(derived.getDefiningOp())) {
           liveValues.insert(iterArg);
           break;
         }
@@ -85,7 +87,7 @@ public:
     }
 
     bool canonicalize = false;
-    Block &block = forOp.region().front();
+    Block &block = forOp.getRegion().front();
     auto yieldOp = cast<scf::YieldOp>(block.getTerminator());
 
     llvm::SmallDenseSet<Value> liveSet;
@@ -93,18 +95,18 @@ public:
     // An internal flat vector of block transfer
     // arguments `newBlockTransferArgs` keeps the 1-1 mapping of original to
     // transformed block argument mappings. This plays the role of a
-    // BlockAndValueMapping for the particular use case of calling into
+    // IRMapping for the particular use case of calling into
     // `mergeBlockBefore`.
     SmallVector<bool, 4> keepMask;
     keepMask.reserve(yieldOp.getNumOperands());
     SmallVector<Value, 4> newBlockTransferArgs, newIterArgs, newYieldValues,
         newResultValues;
-    newBlockTransferArgs.reserve(1 + forOp.getNumIterOperands());
+    newBlockTransferArgs.reserve(1 + forOp.getNumRegionIterArgs());
     newBlockTransferArgs.push_back(Value()); // iv placeholder with null value
-    newIterArgs.reserve(forOp.getNumIterOperands());
+    newIterArgs.reserve(forOp.getNumRegionIterArgs());
     newYieldValues.reserve(yieldOp.getNumOperands());
     newResultValues.reserve(forOp.getNumResults());
-    for (auto it : llvm::zip(forOp.getIterOperands(),   // iter from outside
+    for (auto it : llvm::zip(forOp.getInitArgs(),   // iter from outside
                              forOp.getRegionIterArgs(), // iter inside region
                              forOp.getResults(),        // op results
                              yieldOp.getOperands()      // iter yield
@@ -131,9 +133,9 @@ public:
       return failure();
 
     scf::ForOp newForOp = rewriter.create<scf::ForOp>(
-        forOp.getLoc(), forOp.lowerBound(), forOp.upperBound(), forOp.step(),
+        forOp.getLoc(), forOp.getLowerBound(), forOp.getUpperBound(), forOp.getStep(),
         newIterArgs);
-    Block &newBlock = newForOp.region().front();
+    Block &newBlock = newForOp.getRegion().front();
 
     // Replace the null placeholders with newly constructed values.
     newBlockTransferArgs[0] = newBlock.getArgument(0); // iv
@@ -149,7 +151,7 @@ public:
       }
     }
 
-    Block &oldBlock = forOp.region().front();
+    Block &oldBlock = forOp.getRegion().front();
     assert(oldBlock.getNumArguments() == newBlockTransferArgs.size() &&
            "unexpected argument size mismatch");
 
@@ -158,7 +160,7 @@ public:
     // original terminator that has been merged in.
     if (newIterArgs.empty()) {
       auto newYieldOp = cast<scf::YieldOp>(newBlock.getTerminator());
-      rewriter.mergeBlockBefore(&oldBlock, newYieldOp, newBlockTransferArgs);
+      rewriter.inlineBlockBefore(&oldBlock, newYieldOp, newBlockTransferArgs);
       rewriter.eraseOp(newBlock.getTerminator()->getPrevNode());
       rewriter.replaceOp(forOp, newResultValues);
       return success();
@@ -201,7 +203,7 @@ struct StandaloneDCEPass
     auto *context = &getContext();
     RewritePatternSet patterns(context);
     patterns.add<EliminateUnusedSCFForOpResults>(patterns.getContext());
-    if (failed(applyPatternsAndFoldGreedily(getOperation()->getRegions(),
+    if (failed(applyPatternsAndFoldGreedily(getOperation(),
                                             std::move(patterns)))) {
       signalPassFailure();
     }

--- a/lib/LAGrad/DebugNames.cpp
+++ b/lib/LAGrad/DebugNames.cpp
@@ -115,7 +115,7 @@ void DEBUGpopulateRegion(Region *region, std::fstream &sourceFile,
 
       tokens.clear();
       parseCommaSepParens(src, tokens);
-      assert(tokens.size() == forOp.getNumIterOperands() &&
+      assert(tokens.size() == forOp.getNumRegionIterArgs() &&
              "Mismatch of parsed names and for op iter args");
       for (auto pair : llvm::zip(forOp.getRegionIterArgs(), tokens)) {
         subs = std::get<1>(pair).substr(0, std::get<1>(pair).find('='));
@@ -124,9 +124,9 @@ void DEBUGpopulateRegion(Region *region, std::fstream &sourceFile,
 
       DEBUGpopulateRegion(&forOp.getRegion(), sourceFile, debug_names);
     } else if (auto ifOp = dyn_cast_or_null<scf::IfOp>(&op)) {
-      DEBUGpopulateRegion(&ifOp.thenRegion(), sourceFile, debug_names);
-      DEBUGpopulateRegion(&ifOp.elseRegion(), sourceFile, debug_names);
-    } else if (auto callOp = dyn_cast_or_null<CallOp>(&op)) {
+      DEBUGpopulateRegion(&ifOp.getThenRegion(), sourceFile, debug_names);
+      DEBUGpopulateRegion(&ifOp.getElseRegion(), sourceFile, debug_names);
+    } else if (auto callOp = dyn_cast_or_null<func::CallOp>(&op)) {
       if (callOp.getNumResults() > 1) {
         assert(src.find('=') != std::string::npos &&
                "Expect op line to contain equals sign");
@@ -137,7 +137,7 @@ void DEBUGpopulateRegion(Region *region, std::fstream &sourceFile,
       }
       auto moduleOp = op.getParentOfType<ModuleOp>();
       assert(moduleOp && "module op was null");
-      auto calledFunc = moduleOp.lookupSymbol<FuncOp>(callOp.calleeAttr());
+      auto calledFunc = moduleOp.lookupSymbol<func::FuncOp>(callOp.getCalleeAttr());
       assert(calledFunc && "failed to find called function");
       DEBUGpopulateFunc(debug_names, calledFunc);
     }
@@ -159,7 +159,7 @@ void DEBUGpopulateRegion(Region *region, std::fstream &sourceFile,
   // llvm::errs() << "]\n";
 }
 
-void DEBUGpopulateFunc(NameMap &debug_names, FuncOp funcOp) {
+void DEBUGpopulateFunc(NameMap &debug_names, func::FuncOp funcOp) {
   if (!ENABLE_NAME_DEBUG || funcOp.empty()) {
     return;
   }

--- a/lib/LAGrad/DynamicShapeAnalysis.cpp
+++ b/lib/LAGrad/DynamicShapeAnalysis.cpp
@@ -1,13 +1,14 @@
 #include "LAGrad/Logger.h"
 #include "LAGrad/Utils.h"
-#include "mlir/Dialect/Linalg/IR/LinalgOps.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/Transforms/DialectConversion.h"
 #include "llvm/Support/raw_ostream.h"
 
 using namespace mlir;
 using llvm::errs;
 namespace mlir {
-void analyzeDynamicShapes(LAGradContext &ctx, FuncOp funcOp,
+void analyzeDynamicShapes(LAGradContext &ctx, func::FuncOp funcOp,
                           OpBuilder &builder) {
   OpBuilder::InsertionGuard guard(builder);
   builder.setInsertionPointToStart(&funcOp.getBody().getBlocks().front());
@@ -33,7 +34,7 @@ void analyzeDynamicShapes(LAGradContext &ctx, FuncOp funcOp,
     }
   }
 
-  funcOp.walk([&](linalg::InitTensorOp op) {
+  funcOp.walk([&](tensor::EmptyOp op) {
     RankedTensorType type = op.getType();
     if (type.getNumDynamicDims() > 0) {
       SmallVector<OpFoldResult> shape;
@@ -42,7 +43,7 @@ void analyzeDynamicShapes(LAGradContext &ctx, FuncOp funcOp,
         if (type.isDynamicDim(idx)) {
           shape.push_back(op.getDynamicSize(idx));
         } else {
-          shape.push_back(intToAttr(op.getStaticSize(idx)));
+          shape.push_back(intToAttr(type.getDimSize(idx)));
         }
       }
       ctx.dynamic_shapes.insert(std::make_pair(op.getResult(), shape));
@@ -50,10 +51,11 @@ void analyzeDynamicShapes(LAGradContext &ctx, FuncOp funcOp,
   });
 
   funcOp.walk([&](linalg::LinalgOp op) {
-    if (isa<linalg::InitTensorOp>(op)) {
+    if (isa<tensor::EmptyOp>(op)) {
       return;
     }
-    for (OpOperand *operand : op.getOutputTensorOperands()) {
+    for (int64_t i = 0, e = op.getNumDpsInits(); i < e; ++i) {
+      OpOperand *operand = op.getDpsInitOperand(i);
       if (auto type = operand->get().getType().cast<RankedTensorType>()) {
         if (type.getNumDynamicDims() > 0) {
           assert(ctx.dynamic_shapes.count(operand->get()) &&

--- a/lib/LAGrad/ElementwiseToAffine.cpp
+++ b/lib/LAGrad/ElementwiseToAffine.cpp
@@ -3,9 +3,10 @@
  */
 #include "LAGrad/Passes.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/Bufferization/IR/Bufferization.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
-#include "mlir/Dialect/SCF/SCF.h"
-#include "mlir/Dialect/StandardOps/IR/Ops.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/DialectConversion.h"
@@ -45,12 +46,12 @@ public:
       return failure();
     }
 
-    Value destination = rewriter.create<mlir::memref::AllocOp>(
+    Value destination = rewriter.create<memref::AllocOp>(
         op->getLoc(),
         MemRefType::get(rankedType.getShape(), rankedType.getElementType()));
-    rewriter.create<mlir::AffineForOp>(
+    rewriter.create<affine::AffineForOp>(
         op->getLoc(),
-        /*start=*/0, /*stop=*/rankedType.getShape()[0], /*step=*/1, llvm::None,
+        /*start=*/0, /*stop=*/rankedType.getShape()[0], /*step=*/1, std::nullopt,
         [&](OpBuilder &builder, Location loc, Value value,
             ValueRange regionArgs) {
           // Copied again from the convert-elementwise-to-linalg pass
@@ -65,15 +66,15 @@ public:
                 return type.cast<TensorType>().getElementType();
               }));
           state.addTypes(resultTypes);
-          auto *scalarOp = builder.createOperation(state);
-          builder.create<mlir::AffineStoreOp>(loc, scalarOp->getResult(0),
-                                              destination, value);
-          builder.create<mlir::AffineYieldOp>(loc);
+          auto *scalarOp = builder.create(state);
+          builder.create<affine::AffineStoreOp>(loc, scalarOp->getResult(0),
+                                                destination, value);
+          builder.create<affine::AffineYieldOp>(loc);
         });
     Value result =
-        rewriter.create<mlir::memref::TensorLoadOp>(op->getLoc(), destination);
+        rewriter.create<bufferization::ToTensorOp>(op->getLoc(), destination);
 
-    op->replaceAllUsesWith(llvm::makeArrayRef(result));
+    op->replaceAllUsesWith(ValueRange{result});
     rewriter.eraseOp(op);
     return success();
   }
@@ -86,8 +87,8 @@ private:
     // read from.
     auto definingOp = op->getOperand(arg_index).getDefiningOp();
     if (definingOp &&
-        definingOp->getName().getStringRef() == "std.tensor_load") {
-      return builder.create<mlir::AffineLoadOp>(
+        definingOp->getName().getStringRef() == "bufferization.to_tensor") {
+      return builder.create<affine::AffineLoadOp>(
           loc, op->getOperand(arg_index).getDefiningOp()->getOperand(0), index);
     } else {
       return builder.create<tensor::ExtractOp>(loc, op->getOperand(arg_index),
@@ -98,10 +99,10 @@ private:
 
 struct AffineTarget : public ConversionTarget {
   AffineTarget(MLIRContext &ctx) : ConversionTarget(ctx) {
-    addLegalDialect<mlir::StandardOpsDialect>();
+    addLegalDialect<mlir::func::FuncDialect>();
     addLegalDialect<tensor::TensorDialect>();
     addLegalDialect<mlir::scf::SCFDialect>();
-    addLegalOp<FuncOp>();
+    addLegalOp<func::FuncOp>();
   }
 };
 
@@ -118,7 +119,7 @@ struct ElementwiseToAffineConversionPass
   void runOnOperation() final {
     ConversionTarget target(getContext());
     // target.addLegalOp<ModuleOp, ModuleTerminatorOp>();
-    OwningRewritePatternList patterns(&getContext());
+    RewritePatternSet patterns(&getContext());
     patterns.insert<ElementwiseToAffineLowering>(&getContext());
 
     target.markUnknownOpDynamicallyLegal([](Operation *op) {

--- a/lib/LAGrad/InsertExtractAnalysis.cpp
+++ b/lib/LAGrad/InsertExtractAnalysis.cpp
@@ -1,7 +1,7 @@
 #include "LAGrad/Analysis.h"
 #include "LAGrad/Utils.h"
-#include "mlir/Dialect/Linalg/IR/LinalgOps.h"
-#include "mlir/Dialect/SCF/SCF.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/IR/Dominance.h"
 
@@ -10,14 +10,14 @@ InsertExtractAnalysis::InsertExtractAnalysis(Operation *op) {
   DominanceInfo dom;
   op->walk([&](tensor::ExtractSliceOp op) {
     auto maybeInsertSliceOp = getMatchingInsertSlice(op, dom);
-    if (maybeInsertSliceOp.hasValue()) {
-      extract_to_insert[op] = maybeInsertSliceOp.getValue();
-      matchingInserts.insert(maybeInsertSliceOp.getValue());
+    if (maybeInsertSliceOp.has_value()) {
+      extract_to_insert[op] = maybeInsertSliceOp.value();
+      matchingInserts.insert(maybeInsertSliceOp.value());
       for (auto &use : op.getResult().getUses()) {
         if (auto linalgOp = dyn_cast<linalg::LinalgOp>(use.getOwner())) {
           // Only handle the case where the linalg op has one output for now.
-          if (linalgOp.isOutputTensor(&use) && linalgOp.getNumOutputs() == 1 &&
-              linalgOp.hasTensorSemantics()) {
+          if (linalgOp.isInitTensor(&use) && linalgOp.getNumDpsInits() == 1 &&
+              linalgOp.hasPureTensorSemantics()) {
             linalgInPlaceOps.insert(linalgOp);
           }
         }
@@ -53,19 +53,19 @@ bool InsertExtractAnalysis::isLinalgMarkedForBufferization(
   return linalgInPlaceOps.count(op) > 0;
 }
 
-Optional<tensor::InsertSliceOp>
+std::optional<tensor::InsertSliceOp>
 InsertExtractAnalysis::getMatchingInsertSlice(tensor::ExtractSliceOp op,
                                               const DominanceInfo &dom) const {
   if (disabled)
-    return llvm::None;
+    return std::nullopt;
   // The source of the extract slice should have exactly one use besides the
   // insert slice op.
   size_t domUseCount = 0;
   tensor::InsertSliceOp insertSliceOp;
-  for (Operation *user : op.source().getUsers()) {
+  for (Operation *user : op.getSource().getUsers()) {
     if (dom.properlyDominates(op.getResult(), user)) {
       if (auto iso = dyn_cast<tensor::InsertSliceOp>(user)) {
-        if (iso.dest() == op.source()) {
+        if (iso.getDest() == op.getSource()) {
           insertSliceOp = iso;
         }
       }
@@ -73,7 +73,7 @@ InsertExtractAnalysis::getMatchingInsertSlice(tensor::ExtractSliceOp op,
     }
   }
   if (domUseCount != 1) {
-    return llvm::None;
+    return std::nullopt;
   }
 
   // We ultimately remove the insertSliceOp, so we must ensure that the
@@ -81,7 +81,7 @@ InsertExtractAnalysis::getMatchingInsertSlice(tensor::ExtractSliceOp op,
   bool isWrittenInPlace = false;
   for (OpOperand &use : op.getResult().getUses()) {
     if (auto linalgOp = dyn_cast<linalg::LinalgOp>(use.getOwner())) {
-      if (linalgOp.isOutputTensor(&use)) {
+      if (linalgOp.isInitTensor(&use)) {
         isWrittenInPlace = true;
       }
     } else if (auto forOp = dyn_cast<scf::ForOp>(use.getOwner())) {
@@ -97,7 +97,7 @@ InsertExtractAnalysis::getMatchingInsertSlice(tensor::ExtractSliceOp op,
     SmallVector<Value> frontier{op.getResult()};
     ValueSet derivedFromResult;
     runTopDownDFS(frontier, derivedFromResult);
-    linked = derivedFromResult.contains(insertSliceOp.source());
+    linked = derivedFromResult.contains(insertSliceOp.getSource());
   }
 
   if (linked && isWrittenInPlace && insertSliceOp &&
@@ -106,6 +106,6 @@ InsertExtractAnalysis::getMatchingInsertSlice(tensor::ExtractSliceOp op,
       (insertSliceOp.getMixedStrides() == op.getMixedStrides())) {
     return insertSliceOp;
   }
-  return llvm::None;
+  return std::nullopt;
 }
 } // namespace mlir

--- a/lib/LAGrad/LAGradOps.cpp
+++ b/lib/LAGrad/LAGradOps.cpp
@@ -8,6 +8,7 @@
 
 #include "LAGrad/LAGradOps.h"
 #include "LAGrad/LAGradDialect.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/OpImplementation.h"
 
@@ -16,14 +17,14 @@
 using namespace mlir;
 using namespace lagrad;
 
-static LogicalResult verify(PackOp op) {
-  ShapedType sourceType = op.source().getType().cast<ShapedType>();
-  ShapedType destType = op.getType();
+LogicalResult PackOp::verify() {
+  ShapedType sourceType = getSource().getType().cast<ShapedType>();
+  ShapedType destType = getType();
   if (sourceType.getShape() != destType.getShape()) {
-    return op.emitOpError("Expected source and dest to have same shape");
+    return emitOpError("Expected source and dest to have same shape");
   }
   if (sourceType.getElementType() != destType.getElementType()) {
-    return op.emitOpError("Expected source and dest to have same element type");
+    return emitOpError("Expected source and dest to have same element type");
   }
   return success();
 }
@@ -33,13 +34,13 @@ LogicalResult GradOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
   auto fnAttr = (*this)->getAttrOfType<FlatSymbolRefAttr>("F");
   if (!fnAttr)
     return emitOpError("requires a 'F' symbol reference attribute");
-  FuncOp fn = symbolTable.lookupNearestSymbolFrom<FuncOp>(*this, fnAttr);
+  func::FuncOp fn = symbolTable.lookupNearestSymbolFrom<func::FuncOp>(*this, fnAttr);
   if (!fn)
     return emitOpError() << "'" << fnAttr.getValue()
                          << "' does not reference a valid function";
 
   // Verify that the operand and result types match the callee.
-  auto fnType = fn.getType();
+  auto fnType = fn.getFunctionType();
   bool customGradSignal = (*this)->hasAttrOfType<UnitAttr>("grad_signal");
 
   if (fnType.getNumInputs() !=
@@ -95,7 +96,7 @@ LogicalResult TangentOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
   auto fnAttr = (*this)->getAttrOfType<FlatSymbolRefAttr>("F");
   if (!fnAttr)
     return emitOpError("requires a 'F' symbol reference attribute");
-  FuncOp fn = symbolTable.lookupNearestSymbolFrom<FuncOp>(*this, fnAttr);
+  func::FuncOp fn = symbolTable.lookupNearestSymbolFrom<func::FuncOp>(*this, fnAttr);
   if (!fn)
     return emitOpError() << "'" << fnAttr.getValue()
                          << "' does not reference a valid function";

--- a/lib/LAGrad/LAGradTransforms.cpp
+++ b/lib/LAGrad/LAGradTransforms.cpp
@@ -2,7 +2,9 @@
 #include "LAGrad/LAGradOps.h"
 #include "LAGrad/Transforms.h"
 #include "LAGrad/Utils.h"
-#include "mlir/Dialect/StandardOps/IR/Ops.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/Math/IR/Math.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/Transforms/DialectConversion.h"
 
 #include "llvm/Support/raw_ostream.h"
@@ -13,12 +15,12 @@ using namespace lagrad;
 using llvm::errs;
 namespace {
 
-auto containsEnv(BlockAndValueMapping &map,
+auto containsEnv(IRMapping &map,
                  ConversionPatternRewriter &rewriter) {
   return [&](Value v) { return map.contains(rewriter.getRemappedValue(v)); };
 }
 
-auto lookupEnv(BlockAndValueMapping &map, ConversionPatternRewriter &rewriter) {
+auto lookupEnv(IRMapping &map, ConversionPatternRewriter &rewriter) {
   return [&](Value v) { return map.lookup(rewriter.getRemappedValue(v)); };
 }
 
@@ -33,14 +35,14 @@ SmallVector<Operation *> savePrimalOps(Region *region) {
   return primalOps;
 }
 
-static LogicalResult generateTangent(FuncOp tangentFunc, LAGradContext &ctx,
+static LogicalResult generateTangent(func::FuncOp tangentFunc, LAGradContext &ctx,
                                      ArrayAttr activeArgsAttr,
                                      ConversionPatternRewriter &rewriter,
                                      bool includePrimal, bool sparseSeed);
 
 // TODO: Organize forward mode functions better.
 LogicalResult populateJVP(Operation *op, LAGradContext &ctx,
-                          BlockAndValueMapping &env,
+                          IRMapping &env,
                           ConversionPatternRewriter &rewriter);
 
 void updateActiveValues(LAGradContext &ctx, ValueRange from, ValueRange to) {
@@ -52,7 +54,7 @@ void updateActiveValues(LAGradContext &ctx, ValueRange from, ValueRange to) {
 }
 
 void updateActiveValues(LAGradContext &ctx, Operation *from, Operation *to,
-                        BlockAndValueMapping &map) {
+                        IRMapping &map) {
   updateActiveValues(ctx, from->getResults(), to->getResults());
 
   from->walk([&](Operation *origBodyOp) {
@@ -64,20 +66,20 @@ void updateActiveValues(LAGradContext &ctx, Operation *from, Operation *to,
   });
 }
 
-LogicalResult callJVP(CallOp op, LAGradContext &ctx, BlockAndValueMapping &env,
+LogicalResult callJVP(func::CallOp op, LAGradContext &ctx, IRMapping &env,
                       ConversionPatternRewriter &rewriter) {
-  auto getTangentFunc = [&]() -> FailureOr<FuncOp> {
+  auto getTangentFunc = [&]() -> FailureOr<func::FuncOp> {
     std::string tangentFuncName = ("__tangent_" + op.getCallee()).str();
-    if (auto existingFunc = ctx.moduleOp.lookupSymbol<FuncOp>(tangentFuncName))
+    if (auto existingFunc = ctx.moduleOp.lookupSymbol<func::FuncOp>(tangentFuncName))
       return existingFunc;
 
-    auto originalFuncOp = ctx.moduleOp.lookupSymbol<FuncOp>(op.getCallee());
+    auto originalFuncOp = ctx.moduleOp.lookupSymbol<func::FuncOp>(op.getCallee());
     SmallVector<int64_t> tangentsOf;
     for (auto operand : llvm::enumerate(op.getArgOperands())) {
       if (ctx.activeValues.contains(operand.value()))
         tangentsOf.push_back(operand.index());
     }
-    FuncOp tangentFunc =
+    func::FuncOp tangentFunc =
         copyFunctionDeclaration(originalFuncOp, tangentFuncName, rewriter);
 
     runActivityAnalysis(ctx, tangentFunc, rewriter.getI64ArrayAttr(tangentsOf));
@@ -93,7 +95,7 @@ LogicalResult callJVP(CallOp op, LAGradContext &ctx, BlockAndValueMapping &env,
   if (failed(tangentFuncResult)) {
     return failure();
   }
-  FuncOp tangentFunc = tangentFuncResult.getValue();
+  func::FuncOp tangentFunc = tangentFuncResult.value();
   SmallVector<Value> newOperands;
   DenseMap<unsigned, unsigned> dualMapping;
   SmallVector<std::pair<unsigned, unsigned>> remappedValues;
@@ -111,7 +113,7 @@ LogicalResult callJVP(CallOp op, LAGradContext &ctx, BlockAndValueMapping &env,
   }
 
   auto dualCall =
-      rewriter.create<CallOp>(op.getLoc(), tangentFunc, newOperands);
+      rewriter.create<func::CallOp>(op.getLoc(), tangentFunc, newOperands);
 
   idx = 0, origIdx = 0;
   for (auto result : op.getResults()) {
@@ -141,7 +143,7 @@ LogicalResult callJVP(CallOp op, LAGradContext &ctx, BlockAndValueMapping &env,
 }
 
 LogicalResult linalgJVP(linalg::LinalgOp op, LAGradContext &ctx,
-                        BlockAndValueMapping &env,
+                        IRMapping &env,
                         ConversionPatternRewriter &rewriter) {
   SmallVector<Value> inputs, outputs;
   SmallVector<Type> outputTypes;
@@ -149,23 +151,20 @@ LogicalResult linalgJVP(linalg::LinalgOp op, LAGradContext &ctx,
   DenseMap<unsigned, unsigned> dualMapping;
   SmallVector<std::pair<unsigned, unsigned>> replacedPrimalMapping;
 
-  SmallVector<StringRef> iteratorTypes{op.iterator_types().size()};
-  llvm::transform(
-      op.iterator_types(), iteratorTypes.begin(),
-      [](Attribute attr) { return attr.cast<StringAttr>().getValue(); });
+  SmallVector<utils::IteratorType> iteratorTypes = op.getIteratorTypesArray();
 
   unsigned idx = 0;
   unsigned origIdx = 0;
 
   auto lookupE = lookupEnv(env, rewriter);
   auto containsE = containsEnv(env, rewriter);
-  for (OpOperand *input : op.getInputOperands()) {
+  for (OpOperand *input : op.getDpsInputOperands()) {
     inputs.push_back(input->get());
-    indexingMaps.push_back(op.getTiedIndexingMap(input));
+    indexingMaps.push_back(cast<AffineMapAttr>(op.getIndexingMaps()[input->getOperandNumber()]).getValue());
     replacedPrimalMapping.push_back(std::make_pair(origIdx, idx));
     if (containsE(rewriter.getRemappedValue(input->get()))) {
       inputs.push_back(lookupE(input->get()));
-      indexingMaps.push_back(op.getTiedIndexingMap(input));
+      indexingMaps.push_back(cast<AffineMapAttr>(op.getIndexingMaps()[input->getOperandNumber()]).getValue());
 
       dualMapping[idx] = idx + 1;
       ++idx;
@@ -174,16 +173,17 @@ LogicalResult linalgJVP(linalg::LinalgOp op, LAGradContext &ctx,
     ++origIdx;
   }
 
-  for (OpOperand *output : op.getOutputOperands()) {
+  for (int64_t i = 0, e = op.getNumDpsInits(); i < e; ++i) {
+    OpOperand *output = op.getDpsInitOperand(i);
     outputs.push_back(output->get());
     outputTypes.push_back(output->get().getType());
-    indexingMaps.push_back(op.getTiedIndexingMap(output));
+    indexingMaps.push_back(cast<AffineMapAttr>(op.getIndexingMaps()[output->getOperandNumber()]).getValue());
     replacedPrimalMapping.push_back(std::make_pair(origIdx, idx));
     if (containsE(output->get())) {
       Value dual = lookupE(output->get());
       outputs.push_back(dual);
       outputTypes.push_back(dual.getType());
-      indexingMaps.push_back(op.getTiedIndexingMap(output));
+      indexingMaps.push_back(cast<AffineMapAttr>(op.getIndexingMaps()[output->getOperandNumber()]).getValue());
       dualMapping[idx] = idx + 1;
       ++idx;
     }
@@ -192,7 +192,7 @@ LogicalResult linalgJVP(linalg::LinalgOp op, LAGradContext &ctx,
   }
 
   auto terminator = cast<linalg::YieldOp>(op.getBlock()->getTerminator());
-  BlockAndValueMapping map;
+  IRMapping map;
   bool augmentFailed = false;
   auto newOp = rewriter.create<linalg::GenericOp>(
       op.getLoc(), outputTypes, inputs, outputs, indexingMaps, iteratorTypes,
@@ -229,9 +229,9 @@ LogicalResult linalgJVP(linalg::LinalgOp op, LAGradContext &ctx,
         SmallVector<Value> results;
         results.reserve(outputs.size());
         for (auto mapping : replacedPrimalMapping) {
-          if (mapping.first >= op.getNumInputs()) {
+          if (mapping.first >= op.getNumDpsInputs()) {
             Value newYieldOperand = map.lookup(
-                terminator.getOperand(mapping.first - op.getNumInputs()));
+                terminator.getOperand(mapping.first - op.getNumDpsInputs()));
             results.push_back(newYieldOperand);
             if (dualMapping.count(mapping.second))
               results.push_back(lookupE(newYieldOperand));
@@ -243,26 +243,26 @@ LogicalResult linalgJVP(linalg::LinalgOp op, LAGradContext &ctx,
     return failure();
   }
 
-  SmallVector<Value> replacedResults{static_cast<size_t>(op.getNumOutputs())};
+  SmallVector<Value> replacedResults{static_cast<size_t>(op.getNumDpsInits())};
   for (auto mapping : replacedPrimalMapping) {
-    if (mapping.first >= op.getNumInputs()) {
-      replacedResults[mapping.first - op.getNumInputs()] =
-          newOp.getResult(mapping.second - newOp.getNumInputs());
+    if (mapping.first >= op.getNumDpsInputs()) {
+      replacedResults[mapping.first - op.getNumDpsInputs()] =
+          newOp.getResult(mapping.second - newOp.getNumDpsInputs());
     }
   }
   rewriter.replaceOp(op, replacedResults);
 
   for (auto mapping : dualMapping) {
-    if (mapping.first >= newOp.getNumInputs()) {
-      env.map(newOp.getResult(mapping.first - newOp.getNumInputs()),
-              newOp.getResult(mapping.second - newOp.getNumInputs()));
+    if (mapping.first >= newOp.getNumDpsInputs()) {
+      env.map(newOp.getResult(mapping.first - newOp.getNumDpsInputs()),
+              newOp.getResult(mapping.second - newOp.getNumDpsInputs()));
     }
   }
   return success();
 }
 
 LogicalResult ifJVP(scf::IfOp ifOp, LAGradContext &ctx,
-                    BlockAndValueMapping &env,
+                    IRMapping &env,
                     ConversionPatternRewriter &rewriter) {
   Location loc = ifOp.getLoc();
   SmallVector<Type> resultTypes;
@@ -292,7 +292,7 @@ LogicalResult ifJVP(scf::IfOp ifOp, LAGradContext &ctx,
 
       auto startOfBlock = builder.saveInsertionPoint();
       rewriter.restoreInsertionPoint(startOfBlock);
-      BlockAndValueMapping map;
+      IRMapping map;
 
       // Clone over the original ops.
       SmallVector<Operation *> bodyOps;
@@ -330,8 +330,19 @@ LogicalResult ifJVP(scf::IfOp ifOp, LAGradContext &ctx,
   };
 
   auto augmentedIf = rewriter.create<scf::IfOp>(
-      loc, resultTypes, ifOp.condition(), builderFunc(*ifOp.thenBlock()),
-      builderFunc(*ifOp.elseBlock()));
+      loc, resultTypes, ifOp.getCondition());
+  {
+    OpBuilder::InsertionGuard guard(rewriter);
+    rewriter.setInsertionPointToStart(augmentedIf.thenBlock());
+    auto thenBuilder = builderFunc(*ifOp.thenBlock());
+    thenBuilder(rewriter, augmentedIf.thenBlock()->getParentOp()->getLoc());
+  }
+  {
+    OpBuilder::InsertionGuard guard(rewriter);
+    rewriter.setInsertionPointToStart(augmentedIf.elseBlock());
+    auto elseBuilder = builderFunc(*ifOp.elseBlock());
+    elseBuilder(rewriter, augmentedIf.elseBlock()->getParentOp()->getLoc());
+  }
   SmallVector<Value> replacedResults{replacedPrimalMapping.size()};
   for (auto mapping : replacedPrimalMapping) {
     replacedResults[mapping.first] = augmentedIf.getResult(mapping.second);
@@ -347,7 +358,7 @@ LogicalResult ifJVP(scf::IfOp ifOp, LAGradContext &ctx,
 }
 
 LogicalResult forLoopJVP(scf::ForOp forOp, LAGradContext &ctx,
-                         BlockAndValueMapping &env,
+                         IRMapping &env,
                          ConversionPatternRewriter &rewriter) {
   SmallVector<Value> iterArgInits;
   DenseMap<unsigned, unsigned> dualMapping;
@@ -356,7 +367,7 @@ LogicalResult forLoopJVP(scf::ForOp forOp, LAGradContext &ctx,
   auto containsE = containsEnv(env, rewriter);
   unsigned idx = 0;
   unsigned originalIdx = 0;
-  for (Value iterOperand : forOp.getIterOperands()) {
+  for (Value iterOperand : forOp.getInitArgs()) {
     iterArgInits.push_back(iterOperand);
     replacedPrimalMapping.push_back(std::make_pair(originalIdx, idx));
     if (containsE(iterOperand)) {
@@ -371,10 +382,10 @@ LogicalResult forLoopJVP(scf::ForOp forOp, LAGradContext &ctx,
   auto yieldOp = cast<scf::YieldOp>(forOp.getBody()->getTerminator());
   // Create a new for op because we need to pass additional iteration args
   // with the dual numbers.
-  BlockAndValueMapping map;
+  IRMapping map;
   bool augmentFailed = false;
   auto augmentedFor = rewriter.create<scf::ForOp>(
-      forOp.getLoc(), forOp.lowerBound(), forOp.upperBound(), forOp.step(),
+      forOp.getLoc(), forOp.getLowerBound(), forOp.getUpperBound(), forOp.getStep(),
       iterArgInits,
       [&](OpBuilder &builder, Location loc, Value iv, ValueRange regionArgs) {
         PatternRewriter::InsertionGuard guard(rewriter);
@@ -439,7 +450,7 @@ LogicalResult forLoopJVP(scf::ForOp forOp, LAGradContext &ctx,
 }
 
 LogicalResult populateJVP(Operation *op, LAGradContext &ctx,
-                          BlockAndValueMapping &env,
+                          IRMapping &env,
                           ConversionPatternRewriter &rewriter) {
   rewriter.setInsertionPointAfter(op);
   Location loc = op->getLoc();
@@ -448,10 +459,9 @@ LogicalResult populateJVP(Operation *op, LAGradContext &ctx,
     return success();
   }
   // Need to hit these before the linalg op interface.
-  if (auto initTensorOp = dyn_cast<linalg::InitTensorOp>(op)) {
-    jvp = rewriter.create<linalg::InitTensorOp>(loc, initTensorOp.getType(),
-                                                initTensorOp.getOperands(),
-                                                initTensorOp.static_sizes());
+  if (auto initTensorOp = dyn_cast<tensor::EmptyOp>(op)) {
+    jvp = rewriter.create<tensor::EmptyOp>(loc, initTensorOp.getType(),
+                                                initTensorOp.getDynamicSizes());
     env.map(initTensorOp.getResult(), jvp);
     return success();
   } else if (auto fillOp = dyn_cast<linalg::FillOp>(op)) {
@@ -468,8 +478,8 @@ LogicalResult populateJVP(Operation *op, LAGradContext &ctx,
   } else if (auto forOp = dyn_cast<scf::ForOp>(op)) {
     return forLoopJVP(forOp, ctx, env, rewriter);
   } else if (auto linalgOp = dyn_cast<linalg::LinalgOp>(op)) {
-    return linalgJVP(op, ctx, env, rewriter);
-  } else if (auto callOp = dyn_cast<CallOp>(op)) {
+    return linalgJVP(linalgOp, ctx, env, rewriter);
+  } else if (auto callOp = dyn_cast<func::CallOp>(op)) {
     return callJVP(callOp, ctx, env, rewriter);
   }
 
@@ -484,61 +494,61 @@ LogicalResult populateJVP(Operation *op, LAGradContext &ctx,
   if (auto constOp = dyn_cast<arith::ConstantOp>(op)) {
     if (isFloatOrFloatTensor(constOp.getType())) {
       jvp = getZero(constOp.getLoc(), constOp.getResult(), rewriter);
-    } else if (auto attr = constOp.value().dyn_cast<FloatAttr>()) {
+    } else if (auto attr = constOp.getValue().dyn_cast<FloatAttr>()) {
       // constOp.getType().getIntOrFloatBitWidth()
       jvp = rewriter.create<arith::ConstantOp>(loc,
                                                rewriter.getF64FloatAttr(0.0));
     } else {
       return success();
     }
-  } else if (auto selectOp = dyn_cast<SelectOp>(op)) {
+  } else if (auto selectOp = dyn_cast<arith::SelectOp>(op)) {
     Value trueDual = containsE(selectOp.getTrueValue())
                          ? lookupE(selectOp.getTrueValue())
                          : getZero(loc, selectOp.getTrueValue(), rewriter);
     Value falseDual = containsE(selectOp.getFalseValue())
                           ? lookupE(selectOp.getFalseValue())
                           : getZero(loc, selectOp.getFalseValue(), rewriter);
-    jvp = rewriter.create<SelectOp>(loc, selectOp.getCondition(), trueDual,
+    jvp = rewriter.create<arith::SelectOp>(loc, selectOp.getCondition(), trueDual,
                                     falseDual);
   } else if (auto addfOp = dyn_cast<arith::AddFOp>(op)) {
-    if (!containsE(addfOp.lhs())) {
-      jvp = lookupE(addfOp.rhs());
-    } else if (!containsE(addfOp.rhs())) {
-      jvp = lookupE(addfOp.lhs());
+    if (!containsE(addfOp.getLhs())) {
+      jvp = lookupE(addfOp.getRhs());
+    } else if (!containsE(addfOp.getRhs())) {
+      jvp = lookupE(addfOp.getLhs());
     } else {
-      jvp = rewriter.create<arith::AddFOp>(loc, lookupE(addfOp.lhs()),
-                                           lookupE(addfOp.rhs()));
+      jvp = rewriter.create<arith::AddFOp>(loc, lookupE(addfOp.getLhs()),
+                                           lookupE(addfOp.getRhs()));
     }
   } else if (auto subfOp = dyn_cast<arith::SubFOp>(op)) {
-    jvp = rewriter.create<arith::SubFOp>(loc, lookupE(subfOp.lhs()),
-                                         lookupE(subfOp.rhs()));
+    jvp = rewriter.create<arith::SubFOp>(loc, lookupE(subfOp.getLhs()),
+                                         lookupE(subfOp.getRhs()));
   } else if (auto mulfOp = dyn_cast<arith::MulFOp>(op)) {
-    if (!containsE(mulfOp.lhs())) {
-      jvp = rewriter.create<arith::MulFOp>(loc, mulfOp.lhs(),
-                                           lookupE(mulfOp.rhs()));
-    } else if (!containsE(mulfOp.rhs())) {
-      jvp = rewriter.create<arith::MulFOp>(loc, mulfOp.rhs(),
-                                           lookupE(mulfOp.lhs()));
+    if (!containsE(mulfOp.getLhs())) {
+      jvp = rewriter.create<arith::MulFOp>(loc, mulfOp.getLhs(),
+                                           lookupE(mulfOp.getRhs()));
+    } else if (!containsE(mulfOp.getRhs())) {
+      jvp = rewriter.create<arith::MulFOp>(loc, mulfOp.getRhs(),
+                                           lookupE(mulfOp.getLhs()));
     } else {
       jvp = rewriter.create<arith::AddFOp>(
           loc,
-          rewriter.create<arith::MulFOp>(loc, mulfOp.rhs(),
-                                         lookupE(mulfOp.lhs())),
-          rewriter.create<arith::MulFOp>(loc, mulfOp.lhs(),
-                                         lookupE(mulfOp.rhs())));
+          rewriter.create<arith::MulFOp>(loc, mulfOp.getRhs(),
+                                         lookupE(mulfOp.getLhs())),
+          rewriter.create<arith::MulFOp>(loc, mulfOp.getLhs(),
+                                         lookupE(mulfOp.getRhs())));
     }
   } else if (auto negfOp = dyn_cast<arith::NegFOp>(op)) {
-    jvp = rewriter.create<arith::NegFOp>(loc, lookupE(negfOp.operand()));
+    jvp = rewriter.create<arith::NegFOp>(loc, lookupE(negfOp.getOperand()));
   } else if (auto divfOp = dyn_cast<arith::DivFOp>(op)) {
-    Value lhsDual = rewriter.create<arith::DivFOp>(loc, lookupE(divfOp.lhs()),
-                                                   divfOp.rhs());
+    Value lhsDual = rewriter.create<arith::DivFOp>(loc, lookupE(divfOp.getLhs()),
+                                                   divfOp.getRhs());
 
     // RHS
-    jvp = rewriter.create<arith::MulFOp>(op->getLoc(), lookupE(divfOp.rhs()),
-                                         divfOp.lhs());
+    jvp = rewriter.create<arith::MulFOp>(op->getLoc(), lookupE(divfOp.getRhs()),
+                                         divfOp.getLhs());
     jvp = rewriter.create<arith::NegFOp>(op->getLoc(), jvp);
-    Value denom = rewriter.create<arith::MulFOp>(op->getLoc(), divfOp.rhs(),
-                                                 divfOp.rhs());
+    Value denom = rewriter.create<arith::MulFOp>(op->getLoc(), divfOp.getRhs(),
+                                                 divfOp.getRhs());
     Value rhsDual = rewriter.create<arith::DivFOp>(op->getLoc(), jvp, denom);
 
     jvp = rewriter.create<arith::AddFOp>(loc, lhsDual, rhsDual);
@@ -575,22 +585,22 @@ LogicalResult populateJVP(Operation *op, LAGradContext &ctx,
     jvp = rewriter.create<arith::DivFOp>(loc, lookupE(tanhOp.getOperand()),
                                          coshsquared);
   } else if (auto insertOp = dyn_cast<tensor::InsertOp>(op)) {
-    jvp = rewriter.create<tensor::InsertOp>(loc, lookupE(insertOp.scalar()),
-                                            lookupE(insertOp.dest()),
-                                            insertOp.indices());
+    jvp = rewriter.create<tensor::InsertOp>(loc, lookupE(insertOp.getScalar()),
+                                            lookupE(insertOp.getDest()),
+                                            insertOp.getIndices());
   } else if (auto extractOp = dyn_cast<tensor::ExtractOp>(op)) {
     jvp = rewriter.create<tensor::ExtractOp>(
-        loc, lookupE(rewriter.getRemappedValue(extractOp.tensor())),
-        extractOp.indices());
+        loc, lookupE(rewriter.getRemappedValue(extractOp.getTensor())),
+        extractOp.getIndices());
   } else if (auto insertSliceOp = dyn_cast<tensor::InsertSliceOp>(op)) {
     jvp = rewriter.create<tensor::InsertSliceOp>(
-        loc, lookupE(rewriter.getRemappedValue(insertSliceOp.source())),
-        lookupE(insertSliceOp.dest()), insertSliceOp.getMixedOffsets(),
+        loc, lookupE(rewriter.getRemappedValue(insertSliceOp.getSource())),
+        lookupE(insertSliceOp.getDest()), insertSliceOp.getMixedOffsets(),
         insertSliceOp.getMixedSizes(), insertSliceOp.getMixedStrides());
   } else if (auto extractSliceOp = dyn_cast<tensor::ExtractSliceOp>(op)) {
     jvp = rewriter.create<tensor::ExtractSliceOp>(
         loc, extractSliceOp.getType(),
-        lookupE(rewriter.getRemappedValue(extractSliceOp.source())),
+        lookupE(rewriter.getRemappedValue(extractSliceOp.getSource())),
         extractSliceOp.getMixedOffsets(), extractSliceOp.getMixedSizes(),
         extractSliceOp.getMixedStrides());
   } else {
@@ -601,7 +611,7 @@ LogicalResult populateJVP(Operation *op, LAGradContext &ctx,
   return success();
 }
 
-static LogicalResult generateTangent(FuncOp tangentFunc, LAGradContext &ctx,
+static LogicalResult generateTangent(func::FuncOp tangentFunc, LAGradContext &ctx,
                                      ArrayAttr activeArgsAttr,
                                      ConversionPatternRewriter &rewriter,
                                      bool includePrimal, bool sparseSeed) {
@@ -615,7 +625,7 @@ static LogicalResult generateTangent(FuncOp tangentFunc, LAGradContext &ctx,
   rewriter.setInsertionPointToStart(&region->front());
 
   // env maps primal values to their dual values.
-  BlockAndValueMapping env;
+  IRMapping env;
   size_t idx = 0;
   // Modify the function signature
   DenseSet<size_t> activeArgs;
@@ -641,7 +651,7 @@ static LogicalResult generateTangent(FuncOp tangentFunc, LAGradContext &ctx,
                                         rewriter.getStringAttr("onehot"));
         ctx.sparseValues.insert(arg);
       }
-      tangentFunc.insertArgument(idx, argType, {});
+      tangentFunc.insertArgument(idx, argType, DictionaryAttr(), tangentFunc.getLoc());
       env.map(arg, tangentFunc.getArgument(idx));
     } else if (isFloatOrFloatTensor(arg.getType())) {
       // TODO: modify populateJVP to not need these dummy zero values.
@@ -651,8 +661,8 @@ static LogicalResult generateTangent(FuncOp tangentFunc, LAGradContext &ctx,
   }
 
   if (includePrimal) {
-    SmallVector<Type> results{tangentFunc.getType().getResults().begin(),
-                              tangentFunc.getType().getResults().end()};
+    SmallVector<Type> results(tangentFunc.getFunctionType().getResults().begin(),
+                              tangentFunc.getFunctionType().getResults().end());
     idx = 0;
     for (Type resultType : results) {
       ++idx;
@@ -676,7 +686,7 @@ static LogicalResult generateTangent(FuncOp tangentFunc, LAGradContext &ctx,
       results.push_back(operand);
     results.push_back(lookupE(rewriter.getRemappedValue(operand)));
   }
-  rewriter.create<ReturnOp>(terminator->getLoc(), results);
+  rewriter.create<func::ReturnOp>(terminator->getLoc(), results);
   rewriter.eraseOp(terminator);
   return success();
 }
@@ -691,21 +701,21 @@ public:
     if (!tangentFunc)
       return failure();
 
-    rewriter.replaceOpWithNewOp<CallOp>(op, tangentFunc, op.getOperands());
+    rewriter.replaceOpWithNewOp<func::CallOp>(op, tangentFunc, op.getOperands());
     return success();
   }
 
 private:
-  static FuncOp generateTangentFunc(TangentOp op,
+  static func::FuncOp generateTangentFunc(TangentOp op,
                                     ConversionPatternRewriter &rewriter) {
     auto moduleOp = op->getParentOfType<ModuleOp>();
-    auto originalFuncOp = moduleOp.lookupSymbol<FuncOp>(op.FAttr());
+    auto originalFuncOp = moduleOp.lookupSymbol<func::FuncOp>(op.getFAttr());
     std::string tangentFuncName =
         ("__tangent_" + originalFuncOp.getName()).str();
-    if (auto existingFunc = moduleOp.lookupSymbol<FuncOp>(tangentFuncName))
+    if (auto existingFunc = moduleOp.lookupSymbol<func::FuncOp>(tangentFuncName))
       return existingFunc;
 
-    FuncOp tangentFunc =
+    func::FuncOp tangentFunc =
         copyFunctionDeclaration(originalFuncOp, tangentFuncName, rewriter);
     auto tangentOf = op->getAttrOfType<ArrayAttr>("of");
     bool includePrimal = op->hasAttrOfType<UnitAttr>("include_primal");
@@ -725,7 +735,7 @@ private:
 };
 } // namespace
 
-void mlir::lagrad::populateLAGradTransforms(OwningRewritePatternList &patterns,
+void mlir::lagrad::populateLAGradTransforms(RewritePatternSet &patterns,
                                             MLIRContext *ctx) {
   patterns.add<ForwardModeAD>(ctx);
 }

--- a/lib/LAGrad/LinalgCanonicalize.cpp
+++ b/lib/LAGrad/LinalgCanonicalize.cpp
@@ -6,14 +6,14 @@
 #include "LAGrad/Logger.h"
 #include "LAGrad/Passes.h"
 #include "LAGrad/Utils.h"
-#include "mlir/Dialect/Arithmetic/IR/Arithmetic.h"
-#include "mlir/Dialect/Linalg/IR/LinalgOps.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
-#include "mlir/Dialect/SCF/SCF.h"
-#include "mlir/Dialect/StandardOps/IR/Ops.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/Dialect/Tensor/Transforms/Passes.h"
-#include "mlir/Transforms/Bufferize.h"
+#include "mlir/Dialect/Bufferization/Transforms/Bufferize.h"
 #include "mlir/Transforms/DialectConversion.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "mlir/Transforms/Passes.h"
@@ -31,23 +31,23 @@ public:
   LogicalResult matchAndRewrite(linalg::GenericOp genericOp,
                                 PatternRewriter &rewriter) const override {
     auto regionArgs = genericOp.getBodyRegion().getArguments();
-    auto regionInputArgs = regionArgs.take_front(genericOp.getNumInputs());
+    auto regionInputArgs = regionArgs.take_front(genericOp.getNumDpsInputs());
     bool canonicalize = false;
     SmallVector<Value> new_inputs;
-    new_inputs.reserve(genericOp.getNumInputs());
+    new_inputs.reserve(genericOp.getNumDpsInputs());
     SmallVector<Value> old_region_operands;
-    old_region_operands.reserve(genericOp.getNumInputs());
+    old_region_operands.reserve(genericOp.getNumDpsInputs());
     SmallVector<AffineMap> new_indexing_maps;
     auto indexing_maps = genericOp.getIndexingMaps();
-    new_indexing_maps.reserve(genericOp.getNumInputsAndOutputs());
+    new_indexing_maps.reserve(genericOp.getNumDpsInputs() + genericOp.getNumDpsInits());
     for (size_t i = 0; i < regionInputArgs.size(); i++) {
       auto regionArg = regionInputArgs[i];
       bool unused = regionArg.use_empty();
       canonicalize |= unused;
 
       if (!unused) {
-        new_inputs.push_back(genericOp.getInputOperand(i)->get());
-        new_indexing_maps.push_back(indexing_maps[i]);
+        new_inputs.push_back(genericOp.getDpsInputOperand(i)->get());
+        new_indexing_maps.push_back(cast<AffineMapAttr>(indexing_maps[i]).getValue());
         old_region_operands.push_back(regionArg);
       }
     }
@@ -56,22 +56,22 @@ public:
     }
 
     // Copy over the output indexing maps
-    for (int64_t i = genericOp.getNumInputs();
-         i < genericOp.getNumInputsAndOutputs(); i++) {
-      new_indexing_maps.push_back(indexing_maps[i]);
+    for (int64_t i = genericOp.getNumDpsInputs();
+         i < genericOp.getNumDpsInputs() + genericOp.getNumDpsInits(); i++) {
+      new_indexing_maps.push_back(cast<AffineMapAttr>(indexing_maps[i]).getValue());
     }
     for (auto output_arg : genericOp.getRegionOutputArgs()) {
       old_region_operands.push_back(output_arg);
     }
 
     SmallVector<Value> outputs;
-    outputs.reserve(genericOp.getNumOutputs());
-    for (auto outputOperand : genericOp.getOutputOperands()) {
-      outputs.push_back(outputOperand->get());
+    outputs.reserve(genericOp.getNumDpsInits());
+    for (int64_t i = 0, e = genericOp.getNumDpsInits(); i < e; ++i) {
+      outputs.push_back(genericOp.getDpsInitOperand(i)->get());
     }
 
-    SmallVector<llvm::StringRef> iterator_types{
-        genericOp.iterator_types().getAsValueRange<StringAttr>()};
+    SmallVector<utils::IteratorType> iterator_types =
+        genericOp.getIteratorTypesArray();
 
     SmallVector<Value> genericOperands;
     for (Value arg : genericOp.getBodyRegion().getArguments()) {
@@ -96,8 +96,8 @@ public:
 bool isZeroTensor(Value value) {
   if (auto constantOp =
           dyn_cast_or_null<arith::ConstantOp>(value.getDefiningOp())) {
-    if (auto splatAttr = constantOp.valueAttr().dyn_cast<SplatElementsAttr>()) {
-      if (auto floatAttr = splatAttr.getSplatValue().dyn_cast<FloatAttr>()) {
+    if (auto splatAttr = constantOp.getValueAttr().dyn_cast<SplatElementsAttr>()) {
+      if (auto floatAttr = splatAttr.getSplatValue<Attribute>().dyn_cast<FloatAttr>()) {
         return !floatAttr.getValue().isNonZero();
       }
     }
@@ -107,10 +107,12 @@ bool isZeroTensor(Value value) {
 
 bool isConstantOnesTensor(Value value) {
   if (auto fillOp = dyn_cast_or_null<linalg::FillOp>(value.getDefiningOp())) {
-    if (auto constantFloatOp = dyn_cast_or_null<arith::ConstantFloatOp>(
-            fillOp.value().getDefiningOp())) {
-      if (constantFloatOp.value().convertToDouble() == 1.0) {
-        return true;
+    if (auto constantOp = dyn_cast_or_null<arith::ConstantOp>(
+            fillOp.getDpsInputOperand(0)->get().getDefiningOp())) {
+      if (auto floatAttr = constantOp.getValue().dyn_cast<FloatAttr>()) {
+        if (floatAttr.getValue().convertToDouble() == 1.0) {
+          return true;
+        }
       }
     }
   }
@@ -122,7 +124,7 @@ public:
   using OpRewritePattern::OpRewritePattern;
   LogicalResult matchAndRewrite(linalg::GenericOp op,
                                 PatternRewriter &rewriter) const override {
-    if (!op.hasTensorSemantics()) {
+    if (!op.hasPureTensorSemantics()) {
       return failure();
     }
     if (llvm::none_of(op.getOperands(),
@@ -130,15 +132,15 @@ public:
       return failure();
     }
     size_t idx = 0;
-    for (OpOperand *operand : op.getInputTensorOperands()) {
+    for (OpOperand *operand : op.getDpsInputOperands()) {
       if (isConstantOnesTensor(operand->get()) &&
           op.payloadUsesValueFromOperand(operand)) {
         BlockArgument regionArg = op.getBody()->getArgument(idx);
         for (Operation *user : regionArg.getUsers()) {
           if (auto mulfOp = dyn_cast<arith::MulFOp>(user)) {
             Value other =
-                mulfOp.lhs() == regionArg ? mulfOp.rhs() : mulfOp.lhs();
-            rewriter.updateRootInPlace(
+                mulfOp.getLhs() == regionArg ? mulfOp.getRhs() : mulfOp.getLhs();
+            rewriter.modifyOpInPlace(
                 op, [&]() { rewriter.replaceOp(mulfOp, other); });
             return success();
           }
@@ -155,14 +157,14 @@ public:
   using OpRewritePattern::OpRewritePattern;
   LogicalResult matchAndRewrite(linalg::GenericOp op,
                                 PatternRewriter &rewriter) const override {
-    if (!op.hasTensorSemantics()) {
+    if (!op.hasPureTensorSemantics()) {
       return failure();
     }
     bool isOutputZero =
-        op.getNumResults() == 1 && isZeroTensor(op.getOutputOperand(0)->get());
-    if (!(isOutputZero && op.getNumInputs() == 1 &&
+        op.getNumResults() == 1 && isZeroTensor(op.getDpsInitOperand(0)->get());
+    if (!(isOutputZero && op.getNumDpsInputs() == 1 &&
           op.getOperandTypes()[0].cast<RankedTensorType>() ==
-              op.getOutputTensorTypes()[0])) {
+              op.getDpsInits().getTypes()[0])) {
       return failure();
     }
 
@@ -171,10 +173,10 @@ public:
             yieldOp.getOperand(0).getDefiningOp())) {
       BlockArgument inputArg = op.getBody()->getArgument(0);
       BlockArgument outputArg = op.getBody()->getArgument(1);
-      if ((addfOp.lhs() == inputArg && addfOp.rhs() == outputArg) ||
-          (addfOp.lhs() == outputArg && addfOp.rhs() == inputArg)) {
+      if ((addfOp.getLhs() == inputArg && addfOp.getRhs() == outputArg) ||
+          (addfOp.getLhs() == outputArg && addfOp.getRhs() == inputArg)) {
         errs() << "Replaced addtozero: " << op << "\n";
-        rewriter.replaceOp(op, op.getInputOperand(0)->get());
+        rewriter.replaceOp(op, op.getDpsInputOperand(0)->get());
         return success();
       }
     }
@@ -206,39 +208,42 @@ public:
         if (operand != extractSliceOp.getResult()) {
           if (auto linalgOp =
                   dyn_cast_or_null<linalg::LinalgOp>(operand.getDefiningOp())) {
-            assert(linalgOp.getNumOutputs() == 1 &&
+            assert(linalgOp.getNumDpsInits() == 1 &&
                    "expected linalg op to have 1 output");
-            if (linalgOp.hasTensorSemantics() &&
-                dom.dominates(extractSliceOp.source(), linalgOp) &&
-                isZeroTensor(linalgOp.getOutputTensorOperands()[0]->get())) {
+            if (linalgOp.hasPureTensorSemantics() &&
+                dom.dominates(extractSliceOp.getSource(), linalgOp) &&
+                isZeroTensor(linalgOp.getDpsInits()[0])) {
               rewriter.setInsertionPoint(linalgOp);
               Location loc = op->getLoc();
               auto pairedInsertSlice =
                   ieAnalysis.getPairedInsertSlice(extractSliceOp);
               auto movedExtractSlice = rewriter.create<tensor::ExtractSliceOp>(
-                  loc, extractSliceOp.getType(), extractSliceOp.source(),
+                  loc, extractSliceOp.getType(), extractSliceOp.getSource(),
                   extractSliceOp.getMixedOffsets(),
                   extractSliceOp.getMixedSizes(),
                   extractSliceOp.getMixedStrides());
 
               SmallVector<Value> newOperands;
-              newOperands.reserve(linalgOp.getNumInputsAndOutputs());
-              for (OpOperand *opOperand : linalgOp.getInputTensorOperands()) {
+              newOperands.reserve(linalgOp.getNumDpsInputs() + linalgOp.getNumDpsInits());
+              for (OpOperand *opOperand : linalgOp.getDpsInputOperands()) {
                 newOperands.push_back(opOperand->get());
               }
-              for (OpOperand *opOperand : linalgOp.getOutputTensorOperands()) {
-                if (isZeroTensor(opOperand->get())) {
+              for (int64_t i = 0, e = linalgOp.getNumDpsInits(); i < e; ++i) {
+                Value initVal = linalgOp.getDpsInitOperand(i)->get();
+                if (isZeroTensor(initVal)) {
                   newOperands.push_back(movedExtractSlice.getResult());
                 } else {
                   llvm_unreachable("not yet implemented");
                 }
               }
-              auto clonedOp = linalgOp.clone(
-                  rewriter, loc, linalgOp->getResultTypes(), newOperands);
+              auto clonedOp = rewriter.create(
+                  OperationState(loc, linalgOp->getName().getStringRef(),
+                                 newOperands, linalgOp->getResultTypes(),
+                                 linalgOp->getAttrs()));
               rewriter.replaceOp(extractSliceOp, movedExtractSlice.getResult());
               rewriter.replaceOp(linalgOp, clonedOp->getResults());
               // Creating a new insert slice op segfaults for some reason.
-              pairedInsertSlice.sourceMutable().assign(clonedOp->getResult(0));
+              pairedInsertSlice.getSourceMutable().assign(clonedOp->getResult(0));
               rewriter.eraseOp(user);
               // Logger::blue("Ran fuse paired insert extract");
               return success();
@@ -272,7 +277,7 @@ struct LinalgCanonicalizePass
     // patterns.add<FoldMultiplyByOnes>(patterns.getContext());
     // patterns.add<FoldAddToZero>(patterns.getContext());
     patterns.add<FusePairedInsertExtract>(ieAnalysis, patterns.getContext());
-    if (failed(applyPatternsAndFoldGreedily(getOperation()->getRegions(),
+    if (failed(applyPatternsAndFoldGreedily(getOperation(),
                                             std::move(patterns)))) {
       signalPassFailure();
     }

--- a/lib/LAGrad/LinalgKnownLibraryCalls.cpp
+++ b/lib/LAGrad/LinalgKnownLibraryCalls.cpp
@@ -1,5 +1,7 @@
 #include "LAGrad/Passes.h"
-#include "mlir/Dialect/Linalg/IR/LinalgOps.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "mlir/Transforms/Passes.h"
 #include "llvm/Support/raw_ostream.h"
@@ -26,7 +28,7 @@ static MemRefType convertToFullyDynamicMemRef(MemRefType type) {
   shape.reserve(type.getRank());
   for (int64_t dim = 0; dim < type.getRank(); dim++)
     shape.push_back(-1);
-  return eraseStridedLayout(MemRefType::get(shape, type.getElementType()));
+  return MemRefType::get(shape, type.getElementType());
 }
 
 static SmallVector<Type, 4> extractOperandTypes(Operation *op) {
@@ -77,7 +79,7 @@ FlatSymbolRefAttr getOrInsertFuncDecl(linalg::LinalgOp linalgOp,
 
   auto fnType = rewriter.getFunctionType(extractOperandTypes(linalgOp), {});
   auto funcOp =
-      rewriter.create<FuncOp>(moduleOp.getLoc(), fnNameAttr.getValue(), fnType);
+      rewriter.create<func::FuncOp>(moduleOp.getLoc(), fnNameAttr.getValue(), fnType);
   funcOp->setAttr("llvm.emit_c_interface", UnitAttr::get(ctx));
   funcOp.setPrivate();
   return fnNameAttr;
@@ -90,8 +92,8 @@ public:
 
   LogicalResult matchAndRewrite(linalg::GenericOp genericOp,
                                 PatternRewriter &rewriter) const override {
-    if (genericOp.hasTensorSemantics() ||
-        !genericOp.library_call().hasValue()) {
+    if (genericOp.hasPureTensorSemantics() ||
+        !genericOp.getLibraryCall().has_value()) {
       // Meant to run after bufferization
       return failure();
     }
@@ -99,7 +101,7 @@ public:
     // if/when appropriate
     auto fnNameAttr = getOrInsertFuncDecl(
         genericOp, genericOp.getLibraryCallName(), rewriter);
-    rewriter.replaceOpWithNewOp<CallOp>(
+    rewriter.replaceOpWithNewOp<func::CallOp>(
         genericOp, fnNameAttr, TypeRange(),
         createTypeCanonicalizedMemRefOperands(rewriter, genericOp.getLoc(),
                                               genericOp.getOperands()));
@@ -108,10 +110,24 @@ public:
 };
 
 static unsigned int checkBitWidths(linalg::LinalgOp op) {
-  assert(op.getNumOutputs() > 0);
-  unsigned int bitWidth = op.getOutputBufferTypes()[0].getElementTypeBitWidth();
-  for (OpOperand *operand : op.getInputAndOutputOperands()) {
+  assert(op.getNumDpsInits() > 0);
+  unsigned int bitWidth = op.getDpsInits().getTypes()[0].cast<ShapedType>().getElementTypeBitWidth();
+  for (OpOperand *operand : op.getDpsInputOperands()) {
     Type type = operand->get().getType();
+    if (auto memrefType = type.dyn_cast<MemRefType>()) {
+      if (memrefType.getElementTypeBitWidth() != bitWidth) {
+        assert(false &&
+               "Expected all linalg MemRef operands to have the same bitwidth");
+      }
+    } else if (auto floatType = type.dyn_cast<FloatType>()) {
+      if (floatType.getIntOrFloatBitWidth() != bitWidth) {
+        assert(false &&
+               "Expected all linalg Float operands to have the same bitwidth");
+      }
+    }
+  }
+  for (int64_t i = 0, e = op.getNumDpsInits(); i < e; ++i) {
+    Type type = op.getDpsInitOperand(i)->get().getType();
     if (auto memrefType = type.dyn_cast<MemRefType>()) {
       if (memrefType.getElementTypeBitWidth() != bitWidth) {
         assert(false &&
@@ -132,7 +148,7 @@ public:
   using OpRewritePattern::OpRewritePattern;
   LogicalResult matchAndRewrite(linalg::MatmulOp mmOp,
                                 PatternRewriter &rewriter) const override {
-    if (mmOp.hasTensorSemantics()) {
+    if (mmOp.hasPureTensorSemantics()) {
       return failure();
     }
 
@@ -141,7 +157,7 @@ public:
     fnName[0] = getFloatPrefix(bitWidth);
 
     FlatSymbolRefAttr fnNameAttr = getOrInsertFuncDecl(mmOp, fnName, rewriter);
-    rewriter.replaceOpWithNewOp<CallOp>(
+    rewriter.replaceOpWithNewOp<func::CallOp>(
         mmOp, fnNameAttr, TypeRange(),
         createTypeCanonicalizedMemRefOperands(rewriter, mmOp.getLoc(),
                                               mmOp.getOperands()));
@@ -155,7 +171,7 @@ public:
   LogicalResult matchAndRewrite(linalg::MatvecOp mvOp,
                                 PatternRewriter &rewriter) const override {
     // mvOp.getResult(0).getType().dyn_cast<MemRefType>().getElementTypeBitWidth
-    if (mvOp.hasTensorSemantics()) {
+    if (mvOp.hasPureTensorSemantics()) {
       return failure();
     }
 
@@ -164,7 +180,7 @@ public:
     fnName[0] = getFloatPrefix(bitWidth);
 
     FlatSymbolRefAttr fnNameAttr = getOrInsertFuncDecl(mvOp, fnName, rewriter);
-    rewriter.replaceOpWithNewOp<CallOp>(
+    rewriter.replaceOpWithNewOp<func::CallOp>(
         mvOp, fnNameAttr, TypeRange(),
         createTypeCanonicalizedMemRefOperands(rewriter, mvOp.getLoc(),
                                               mvOp.getOperands()));
@@ -177,7 +193,7 @@ public:
   using OpRewritePattern::OpRewritePattern;
   LogicalResult matchAndRewrite(linalg::DotOp op,
                                 PatternRewriter &rewriter) const override {
-    if (op.hasTensorSemantics()) {
+    if (op.hasPureTensorSemantics()) {
       return failure();
     }
     unsigned int bitWidth = checkBitWidths(op);
@@ -186,7 +202,7 @@ public:
     std::string fnName = "ddot";
     fnName[0] = getFloatPrefix(bitWidth);
     FlatSymbolRefAttr fnNameAttr = getOrInsertFuncDecl(op, fnName, rewriter);
-    rewriter.replaceOpWithNewOp<CallOp>(
+    rewriter.replaceOpWithNewOp<func::CallOp>(
         op, fnNameAttr, TypeRange(),
         createTypeCanonicalizedMemRefOperands(rewriter, op.getLoc(),
                                               op.getOperands()));
@@ -214,7 +230,7 @@ struct LinalgKnownLibraryCallPass
     patterns.add<ReplaceMatmul>(patterns.getContext());
     patterns.add<ReplaceMatVec>(patterns.getContext());
     patterns.add<ReplaceDot>(patterns.getContext());
-    if (failed(applyPatternsAndFoldGreedily(getOperation()->getRegions(),
+    if (failed(applyPatternsAndFoldGreedily(getOperation(),
                                             std::move(patterns)))) {
       signalPassFailure();
     }

--- a/lib/LAGrad/LinalgVectorJacobianProducts.cpp
+++ b/lib/LAGrad/LinalgVectorJacobianProducts.cpp
@@ -1,6 +1,6 @@
 #include "LAGrad/Utils.h"
-#include "mlir/Dialect/Arithmetic/IR/Arithmetic.h"
-#include "mlir/Dialect/Linalg/IR/LinalgOps.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Transforms/DialectConversion.h"
 
 namespace mlir {
@@ -8,18 +8,21 @@ Value reverseGenericOp(linalg::GenericOp op, LAGradContext &ctx, Value operand,
                        Value vjp_value, int op_index, Value output,
                        ConversionPatternRewriter &rewriter) {
   // Need to ensure:
-  // if (op_index > (size_t)genericOp.getNumInputs() - 1)
+  // if (op_index > (size_t)genericOp.getNumDpsInputs() - 1)
   //   continue;
-  auto numIterators = op.iterator_types().size();
+  auto numIterators = op.getIteratorTypesArray().size();
   SmallVector<AffineMap, 6> indexing_maps(
       op->getNumOperands() + 1, rewriter.getMultiDimIdentityMap(numIterators));
-  SmallVector<StringRef, 6> iterator_types(numIterators,
-                                           getParallelIteratorTypeName());
+  SmallVector<utils::IteratorType, 6> iterator_types(numIterators,
+                                                     utils::IteratorType::parallel);
 
   auto outputShape = output.getType().dyn_cast_or_null<ShapedType>();
   assert(outputShape && outputShape.hasRank() &&
          "output must be a ranked type");
-  SmallVector<AffineMap> generic_indexing_maps = op.getIndexingMaps();
+  SmallVector<AffineMap> generic_indexing_maps;
+  for (auto attr : op.getIndexingMaps()) {
+    generic_indexing_maps.push_back(cast<AffineMapAttr>(attr).getValue());
+  }
   unsigned int op_count = op.getNumOperands();
   SmallVector<Value> inputs;
   for (size_t i = 0; i < op_count; i++) {
@@ -37,7 +40,7 @@ Value reverseGenericOp(linalg::GenericOp op, LAGradContext &ctx, Value operand,
         AffineMap outputMap = generic_indexing_maps[op_index];
         for (size_t idx = 0; idx < outputMap.getNumDims(); idx++) {
           if (!outputMap.isFunctionOfDim(idx)) {
-            iterator_types[idx] = getReductionIteratorTypeName();
+            iterator_types[idx] = utils::IteratorType::reduction;
           }
         }
       }
@@ -67,7 +70,7 @@ Value reverseGenericOp(linalg::GenericOp op, LAGradContext &ctx, Value operand,
       [&](OpBuilder &builder, Location loc, ValueRange regionArgs) {
         PatternRewriter::InsertionGuard insertionGuard(rewriter);
         SmallVector<mlir::Operation *> genericRegionOps =
-            cloneBasicBlock(op.getOps(), builder, regionArgs, genericOperands);
+            cloneBasicBlock(llvm::make_range(op.getBodyRegion().op_begin(), op.getBodyRegion().op_end()), builder, regionArgs, genericOperands);
 
         for (auto it = genericRegionOps.rbegin(); it != genericRegionOps.rend();
              it++) {

--- a/lib/LAGrad/LoopAllocHoisting.cpp
+++ b/lib/LAGrad/LoopAllocHoisting.cpp
@@ -4,14 +4,14 @@
  */
 
 #include "LAGrad/Passes.h"
-#include "mlir/Dialect/Arithmetic/IR/Arithmetic.h"
-#include "mlir/Dialect/Linalg/IR/LinalgOps.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
-#include "mlir/Dialect/SCF/SCF.h"
-#include "mlir/Dialect/StandardOps/IR/Ops.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/Dialect/Tensor/Transforms/Passes.h"
-#include "mlir/Transforms/Bufferize.h"
+#include "mlir/Dialect/Bufferization/Transforms/Bufferize.h"
 #include "mlir/Transforms/DialectConversion.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "mlir/Transforms/Passes.h"
@@ -28,13 +28,13 @@ public:
 
   LogicalResult matchAndRewrite(scf::ForOp forOp,
                                 PatternRewriter &rewriter) const override {
-    if (llvm::none_of(forOp.getIterOperands(), [](Value iter_op) {
+    if (llvm::none_of(forOp.getInitArgs(), [](Value iter_op) {
           assert(iter_op && "iter op was null");
           return iter_op.getType().isa<MemRefType>();
         })) {
       return failure();
     }
-    auto yieldOp = cast<scf::YieldOp>(forOp.region().front().getTerminator());
+    auto yieldOp = cast<scf::YieldOp>(forOp.getRegion().front().getTerminator());
     SmallVector<Operation *, 4> allocsToHoist;
     forOp.walk([&](memref::AllocOp allocOp) {
       for (auto operand : yieldOp.getOperands()) {
@@ -46,9 +46,9 @@ public:
     if (allocsToHoist.empty()) {
       return failure();
     }
-    rewriter.updateRootInPlace(forOp, [&]() {
-      if (failed(forOp.moveOutOfLoop(allocsToHoist))) {
-        assert(false && "failed to move allocs out of loop");
+    rewriter.modifyOpInPlace(forOp, [&]() {
+      for (Operation *allocOp : allocsToHoist) {
+        allocOp->moveBefore(forOp);
       }
     });
 
@@ -73,7 +73,7 @@ struct StandaloneLoopHoistingPass
     auto *context = &getContext();
     RewritePatternSet patterns(context);
     patterns.add<HoistLoopAllocs>(patterns.getContext());
-    if (failed(applyPatternsAndFoldGreedily(getOperation()->getRegions(),
+    if (failed(applyPatternsAndFoldGreedily(getOperation(),
                                             std::move(patterns)))) {
       signalPassFailure();
     }

--- a/lib/LAGrad/LoopNestAnalysis.cpp
+++ b/lib/LAGrad/LoopNestAnalysis.cpp
@@ -7,14 +7,14 @@ Value getInductionVar(scf::ForOp op, LoopNest &loopNest) {
     if (auto subiOp =
             dyn_cast<arith::SubIOp>(*op.getInductionVar().getUsers().begin())) {
       // case 1: (ub - iv) - 1
-      if (subiOp.lhs() == op.upperBound() &&
-          subiOp.rhs() == op.getInductionVar() &&
+      if (subiOp.getLhs() == op.getUpperBound() &&
+          subiOp.getRhs() == op.getInductionVar() &&
           subiOp.getResult().hasOneUse()) {
         if (auto secondSubiOp = dyn_cast<arith::SubIOp>(
                 *subiOp.getResult().getUsers().begin())) {
           auto rhs = dyn_cast_or_null<arith::ConstantIndexOp>(
-              secondSubiOp.rhs().getDefiningOp());
-          if (secondSubiOp.lhs() == subiOp.getResult() && rhs &&
+              secondSubiOp.getRhs().getDefiningOp());
+          if (secondSubiOp.getLhs() == subiOp.getResult() && rhs &&
               rhs.value() == 1) {
             loopNest.ivComputation.insert(subiOp);
             loopNest.ivComputation.insert(secondSubiOp);
@@ -24,10 +24,10 @@ Value getInductionVar(scf::ForOp op, LoopNest &loopNest) {
       } else {
         // case 2: (const ub - 1) - iv
         auto constLHS = dyn_cast_or_null<arith::ConstantIndexOp>(
-            subiOp.lhs().getDefiningOp());
+            subiOp.getLhs().getDefiningOp());
         auto constUpperBound = dyn_cast_or_null<arith::ConstantIndexOp>(
-            op.upperBound().getDefiningOp());
-        if (subiOp.rhs() == op.getInductionVar() && constLHS &&
+            op.getUpperBound().getDefiningOp());
+        if (subiOp.getRhs() == op.getInductionVar() && constLHS &&
             constUpperBound &&
             constLHS.value() == constUpperBound.value() - 1) {
           loopNest.ivComputation.insert(subiOp);
@@ -40,7 +40,7 @@ Value getInductionVar(scf::ForOp op, LoopNest &loopNest) {
 }
 
 using llvm::errs;
-Optional<std::pair<Value, Value>> traverseTiedLoopOperands(Value regionArg) {
+std::optional<std::pair<Value, Value>> traverseTiedLoopOperands(Value regionArg) {
   // errs() << "traversing tied loop operands for region arg " << regionArg
   //        << "\n";
   Value tensor = regionArg;
@@ -48,26 +48,26 @@ Optional<std::pair<Value, Value>> traverseTiedLoopOperands(Value regionArg) {
   while (auto parentForOp =
              dyn_cast<scf::ForOp>(tensor.getParentRegion()->getParentOp())) {
     OpOperand *iterOperand =
-        llvm::find_if(parentForOp.getIterOpOperands(), [&](OpOperand &operand) {
-          return parentForOp.getRegionIterArgForOpOperand(operand) == tensor;
+        llvm::find_if(parentForOp.getInitArgsMutable(), [&](OpOperand &operand) {
+          return parentForOp.getTiedLoopResult(&operand) == tensor;
         });
-    if (iterOperand == parentForOp.getIterOpOperands().end()) {
-      return llvm::None;
+    if (iterOperand == parentForOp.getInitArgsMutable().end()) {
+      return std::nullopt;
     }
     tensor = iterOperand->get();
-    result = parentForOp.getResultForOpOperand(*iterOperand);
+    result = parentForOp.getTiedLoopResult(&*iterOperand);
   }
   return std::make_pair(tensor, result);
 }
 
 bool isPaired(tensor::ExtractOp read, tensor::InsertOp write) {
-  if (!(read.tensor() == write.dest() && read.indices() == write.indices())) {
+  if (!(read.getTensor() == write.getDest() && read.getIndices() == write.getIndices())) {
     return false;
   }
 
   // The read tensor should only be used by the write.
   DominanceInfo dom;
-  for (Operation *user : read.tensor().getUsers()) {
+  for (Operation *user : read.getTensor().getUsers()) {
     if (dom.properlyDominates(read.getResult(), user) && user != write) {
       return false;
     }
@@ -75,9 +75,9 @@ bool isPaired(tensor::ExtractOp read, tensor::InsertOp write) {
   return true;
 }
 
-Optional<LoopNest> parseLoopNest(scf::ForOp op) {
+std::optional<LoopNest> parseLoopNest(scf::ForOp op) {
   if (op->getParentOfType<scf::ForOp>()) {
-    return llvm::None;
+    return std::nullopt;
   }
 
   LoopNest loopNest;
@@ -110,7 +110,7 @@ Optional<LoopNest> parseLoopNest(scf::ForOp op) {
         }
         // need to find all the reads that affect the scalar within the loop
         // body
-        SmallVector<Value> frontier{insertOp.scalar()};
+        SmallVector<Value> frontier{insertOp.getScalar()};
         while (!frontier.empty()) {
           Value val = frontier.pop_back_val();
           if (Operation *definingOp = val.getDefiningOp()) {
@@ -128,30 +128,30 @@ Optional<LoopNest> parseLoopNest(scf::ForOp op) {
 
         for (Operation *read : activeReads) {
           auto extractOp = cast<tensor::ExtractOp>(read);
-          if (extractOp.tensor() == insertOp.dest()) {
+          if (extractOp.getTensor() == insertOp.getDest()) {
             // This extract op is an output operand
             tensor::InsertOp tmpInsert = insertOp;
             unsigned numWrites = 1;
             while (auto prevWrite = dyn_cast_or_null<tensor::InsertOp>(
-                       tmpInsert.dest().getDefiningOp())) {
+                       tmpInsert.getDest().getDefiningOp())) {
               tmpInsert = prevWrite;
               numWrites++;
             }
 
-            loopNest.outputRegionArgs.push_back(tmpInsert.dest());
+            loopNest.outputRegionArgs.push_back(tmpInsert.getDest());
             loopNest.outputPerIterWrites.push_back(numWrites);
             auto maybeOutputOperand =
-                traverseTiedLoopOperands(tmpInsert.dest());
-            if (!maybeOutputOperand.hasValue()) {
+                traverseTiedLoopOperands(tmpInsert.getDest());
+            if (!maybeOutputOperand.has_value()) {
               // errs() << "interrupt output\n";
               return WalkResult::interrupt();
             }
             loopNest.outputTensorOperands.push_back(
-                maybeOutputOperand.getValue().first);
-            loopNest.results.push_back(maybeOutputOperand.getValue().second);
+                maybeOutputOperand.value().first);
+            loopNest.results.push_back(maybeOutputOperand.value().second);
           } else {
             SmallVector<AffineExpr, 4> resultExprs;
-            for (Value idxVal : extractOp.indices()) {
+            for (Value idxVal : extractOp.getIndices()) {
               ptrdiff_t idx = std::distance(
                   loopNest.inductionVars.begin(),
                   std::find(loopNest.inductionVars.begin(),
@@ -179,14 +179,14 @@ Optional<LoopNest> parseLoopNest(scf::ForOp op) {
             // TODO: This analysis is super prototypal, it just needs to work
             // for the hand offline benchmark.
             if (auto tmpInsert = dyn_cast_or_null<tensor::InsertOp>(
-                    extractOp.tensor().getDefiningOp())) {
+                    extractOp.getTensor().getDefiningOp())) {
               while (auto prevWrite = dyn_cast_or_null<tensor::InsertOp>(
-                         tmpInsert.dest().getDefiningOp())) {
+                         tmpInsert.getDest().getDefiningOp())) {
                 tmpInsert = prevWrite;
               }
               if (llvm::none_of(forOp.getRegionIterArgs(),
                                 [&tmpInsert](BlockArgument iterArg) {
-                                  return tmpInsert.dest() == iterArg;
+                                  return tmpInsert.getDest() == iterArg;
                                 })) {
                 // The active read was not a result of a loop region arg.
                 return WalkResult::interrupt();
@@ -194,23 +194,23 @@ Optional<LoopNest> parseLoopNest(scf::ForOp op) {
             } else {
               if (std::find(loopNest.inputRegionArgs.begin(),
                             loopNest.inputRegionArgs.end(),
-                            extractOp.tensor()) !=
+                            extractOp.getTensor()) !=
                   loopNest.inputRegionArgs.end()) {
                 // TODO: worth looking into why this happens
                 continue;
               }
-              loopNest.inputRegionArgs.push_back(extractOp.tensor());
+              loopNest.inputRegionArgs.push_back(extractOp.getTensor());
               loopNest.inputMaps.push_back(AffineMap::get(
                   loopNest.inductionVars.size(),
                   /*symbolCount=*/0, resultExprs, op.getContext()));
               auto maybeInputOperand =
-                  traverseTiedLoopOperands(extractOp.tensor());
-              if (!maybeInputOperand.hasValue()) {
+                  traverseTiedLoopOperands(extractOp.getTensor());
+              if (!maybeInputOperand.has_value()) {
                 // errs() << "interrupt 4\n";
                 return WalkResult::interrupt();
               }
               loopNest.inputTensorOperands.push_back(
-                  maybeInputOperand.getValue().first);
+                  maybeInputOperand.value().first);
             }
           }
         }
@@ -246,7 +246,7 @@ Optional<LoopNest> parseLoopNest(scf::ForOp op) {
     return WalkResult::advance();
   });
   if (result.wasInterrupted()) {
-    return llvm::None;
+    return std::nullopt;
   }
   return loopNest;
 }
@@ -254,15 +254,15 @@ Optional<LoopNest> parseLoopNest(scf::ForOp op) {
 LoopNestAnalysis::LoopNestAnalysis(Operation *op) {
   op->walk([&](scf::ForOp forOp) {
     auto maybeNest = parseLoopNest(forOp);
-    if (maybeNest.hasValue()) {
-      forOpMapping[forOp] = maybeNest.getValue();
+    if (maybeNest.has_value()) {
+      forOpMapping[forOp] = maybeNest.value();
     }
   });
 }
 
-Optional<LoopNest> LoopNestAnalysis::getLoopNest(scf::ForOp op) const {
+std::optional<LoopNest> LoopNestAnalysis::getLoopNest(scf::ForOp op) const {
   if (forOpMapping.count(op) == 0) {
-    return llvm::None;
+    return std::nullopt;
   }
   return forOpMapping.lookup(op);
 }

--- a/lib/LAGrad/LowerGrad.cpp
+++ b/lib/LAGrad/LowerGrad.cpp
@@ -3,10 +3,13 @@
 #include "LAGrad/Passes.h"
 #include "LAGrad/Transforms.h"
 #include "LAGrad/Utils.h"
-#include "mlir/Dialect/Arithmetic/IR/Arithmetic.h"
-#include "mlir/Dialect/Linalg/IR/LinalgOps.h"
-#include "mlir/Dialect/SCF/SCF.h"
-#include "mlir/Dialect/StandardOps/IR/Ops.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/Math/IR/Math.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/DialectConversion.h"
 
@@ -27,19 +30,19 @@ public:
       return failure();
     }
 
-    rewriter.replaceOpWithNewOp<CallOp>(op, funcOp, op.getOperands());
+    rewriter.replaceOpWithNewOp<func::CallOp>(op, funcOp, op.getOperands());
     return success();
   }
 
 private:
-  static FuncOp generateAdjointFunc(lagrad::GradOp gradOp,
+  static func::FuncOp generateAdjointFunc(lagrad::GradOp gradOp,
                                     ConversionPatternRewriter &rewriter) {
     auto moduleOp = gradOp->getParentOfType<ModuleOp>();
-    auto originalFuncOp = moduleOp.lookupSymbol<FuncOp>(gradOp.FAttr());
+    auto originalFuncOp = moduleOp.lookupSymbol<func::FuncOp>(gradOp.getFAttr());
 
     std::string adjointFuncName = ("__grad_" + originalFuncOp.getName()).str();
 
-    if (auto existingAdjoint = moduleOp.lookupSymbol<FuncOp>(adjointFuncName)) {
+    if (auto existingAdjoint = moduleOp.lookupSymbol<func::FuncOp>(adjointFuncName)) {
       return existingAdjoint;
     }
 
@@ -52,7 +55,7 @@ private:
 
     // If we received request for a custom gradient signal, this is equivalent
     // to taking in the gradient signal as a parameter.
-    FuncOp funcOp =
+    func::FuncOp funcOp =
         copyFunctionDeclaration(originalFuncOp, adjointFuncName, rewriter);
     LAGradContext lagradctx{moduleOp};
     DEBUGpopulateFunc(lagradctx.debug_names, funcOp);
@@ -69,8 +72,8 @@ private:
 namespace {
 struct GradTarget : public ConversionTarget {
   GradTarget(MLIRContext &ctx) : ConversionTarget(ctx) {
-    addLegalDialect<mlir::StandardOpsDialect>();
-    addLegalDialect<mlir::arith::ArithmeticDialect>();
+    addLegalDialect<mlir::func::FuncDialect>();
+    addLegalDialect<mlir::arith::ArithDialect>();
     addLegalDialect<mlir::math::MathDialect>();
     addLegalDialect<mlir::memref::MemRefDialect>();
     addLegalDialect<tensor::TensorDialect>();
@@ -78,7 +81,7 @@ struct GradTarget : public ConversionTarget {
     addLegalDialect<linalg::LinalgDialect>();
     addIllegalDialect<lagrad::LAGradDialect>();
     addLegalOp<lagrad::PackOp>();
-    addLegalOp<FuncOp>();
+    addLegalOp<func::FuncOp>();
   }
 };
 } // end anonymous namespace
@@ -101,7 +104,7 @@ void GradConversionPass::runOnOperation() {
   GradTarget target(getContext());
   target.addLegalOp<ModuleOp>();
 
-  OwningRewritePatternList patterns(&getContext());
+  RewritePatternSet patterns(&getContext());
   patterns.insert<GradOpLowering>(&getContext());
   lagrad::populateLAGradTransforms(patterns, &getContext());
 

--- a/lib/LAGrad/LowerToLLVM.cpp
+++ b/lib/LAGrad/LowerToLLVM.cpp
@@ -2,15 +2,15 @@
 #include "LAGrad/LAGradDialect.h"
 #include "LAGrad/LAGradOps.h"
 
-#include "mlir/Conversion/ArithmeticToLLVM/ArithmeticToLLVM.h"
+#include "mlir/Conversion/ArithToLLVM/ArithToLLVM.h"
 #include "mlir/Conversion/LLVMCommon/ConversionTarget.h"
 #include "mlir/Conversion/LLVMCommon/TypeConverter.h"
 #include "mlir/Conversion/MemRefToLLVM/MemRefToLLVM.h"
-#include "mlir/Conversion/SCFToStandard/SCFToStandard.h"
-#include "mlir/Conversion/StandardToLLVM/ConvertStandardToLLVM.h"
-#include "mlir/Dialect/Arithmetic/IR/Arithmetic.h"
+#include "mlir/Conversion/SCFToControlFlow/SCFToControlFlow.h"
+#include "mlir/Conversion/FuncToLLVM/ConvertFuncToLLVM.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
-#include "mlir/Dialect/StandardOps/IR/Ops.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/DialectConversion.h"
 
@@ -60,8 +60,7 @@ public:
 
     auto sym = getOrInsertAutodiffDecl(rewriter, op, floatType);
     auto const_global = getOrInsertEnzymeConstDecl(rewriter, op);
-    auto llvmI8PtrTy =
-        LLVM::LLVMPointerType::get(IntegerType::get(op->getContext(), 8));
+    auto llvmI8PtrTy = LLVM::LLVMPointerType::get(op->getContext());
     auto enzyme_const_addr = rewriter.create<LLVM::AddressOfOp>(
         op->getLoc(), llvmI8PtrTy, const_global);
 
@@ -74,7 +73,7 @@ public:
     LLVMTypeConverter typeConverter(op->getContext());
 
     for (auto it = result.use_begin(); it != result.use_end(); it++) {
-      auto user = dyn_cast_or_null<CallIndirectOp>(it.getUser());
+      auto user = dyn_cast_or_null<func::CallIndirectOp>(it.getUser());
       assert(user && "Expected user to be a CallIndirectOp");
       // Copy over the arguments for the op
       auto arguments = SmallVector<Value>();
@@ -92,8 +91,7 @@ public:
           assert(memrefType && "Operator marked const was not a MemRef");
         }
         if (memrefType && memrefType.getElementType().isa<FloatType>()) {
-          auto pointeeType =
-              LLVM::LLVMPointerType::get(memrefType.getElementType());
+          auto pointeeType = LLVM::LLVMPointerType::get(op->getContext());
           auto rank = memrefType.getRank();
           // Ignore the first pointer
           arguments.push_back(enzyme_const_addr.getResult());
@@ -105,7 +103,7 @@ public:
           arguments.push_back(rewriter
                                   .create<LLVM::ExtractValueOp>(
                                       user->getLoc(), pointeeType, casted,
-                                      rewriter.getI64ArrayAttr(0))
+                                      ArrayRef<int64_t>{0})
                                   .getResult());
 
           if (constSet.contains(arg_index)) {
@@ -115,7 +113,7 @@ public:
           arguments.push_back(rewriter
                                   .create<LLVM::ExtractValueOp>(
                                       user->getLoc(), pointeeType, casted,
-                                      rewriter.getI64ArrayAttr(1))
+                                      ArrayRef<int64_t>{1})
                                   .getResult());
 
           if (!constSet.contains(arg_index)) {
@@ -131,7 +129,7 @@ public:
                     .getResult(0);
             auto extractShadowOp = rewriter.create<LLVM::ExtractValueOp>(
                 shadow.getLoc(), pointeeType, shadowCasted,
-                rewriter.getI64ArrayAttr(1));
+                ArrayRef<int64_t>{1});
             arguments.push_back(extractShadowOp.getResult());
           }
 
@@ -139,20 +137,20 @@ public:
           arguments.push_back(rewriter
                                   .create<LLVM::ExtractValueOp>(
                                       user->getLoc(), llvmI64Ty, casted,
-                                      rewriter.getI64ArrayAttr(2))
+                                      ArrayRef<int64_t>{2})
                                   .getResult());
           for (int64_t i = 0; i < rank; ++i) {
             arguments.push_back(rewriter
                                     .create<LLVM::ExtractValueOp>(
                                         user->getLoc(), llvmI64Ty, casted,
-                                        rewriter.getI64ArrayAttr({3, i}))
+                                        ArrayRef<int64_t>{3, i})
                                     .getResult());
           }
           for (int64_t i = 0; i < rank; ++i) {
             arguments.push_back(rewriter
                                     .create<LLVM::ExtractValueOp>(
                                         user->getLoc(), llvmI64Ty, casted,
-                                        rewriter.getI64ArrayAttr({4, i}))
+                                        ArrayRef<int64_t>{4, i})
                                     .getResult());
           }
         } else {
@@ -161,7 +159,7 @@ public:
         arg_index++;
       }
 
-      rewriter.replaceOpWithNewOp<CallOp>(user, sym, primalType.getResults(),
+      rewriter.replaceOpWithNewOp<func::CallOp>(user, sym, primalType.getResults(),
                                           arguments);
     }
 
@@ -197,7 +195,7 @@ private:
     }
 
     // Create the function declaration for __enzyme_autodiff
-    auto voidPtrType = LLVM::LLVMPointerType::get(IntegerType::get(context, 8));
+    auto voidPtrType = LLVM::LLVMPointerType::get(context);
 
     auto llvmFnType =
         LLVM::LLVMFunctionType::get(returnType, voidPtrType, /*isVarArg=*/true);
@@ -236,11 +234,11 @@ void StandaloneToLLVMLoweringPass::runOnOperation() {
 
   LLVMTypeConverter typeConverter(&getContext());
 
-  OwningRewritePatternList patterns(&getContext());
-  populateLoopToStdConversionPatterns(patterns);
-  populateMemRefToLLVMConversionPatterns(typeConverter, patterns);
-  arith::populateArithmeticToLLVMConversionPatterns(typeConverter, patterns);
-  populateStdToLLVMConversionPatterns(typeConverter, patterns);
+  RewritePatternSet patterns(&getContext());
+  populateSCFToControlFlowConversionPatterns(patterns);
+  populateFinalizeMemRefToLLVMConversionPatterns(typeConverter, patterns);
+  arith::populateArithToLLVMConversionPatterns(typeConverter, patterns);
+  populateFuncToLLVMConversionPatterns(typeConverter, patterns);
   patterns.insert<DiffOpLowering>(&getContext());
 
   auto mod = getOperation();

--- a/lib/LAGrad/PrimalCaching.cpp
+++ b/lib/LAGrad/PrimalCaching.cpp
@@ -1,5 +1,9 @@
 #include "LAGrad/Utils.h"
-#include "mlir/Dialect/SCF/SCF.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Bufferization/IR/Bufferization.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Transforms/DialectConversion.h"
 #include "llvm/Support/raw_ostream.h"
 
@@ -10,12 +14,12 @@ static inline void markAsCache(Operation *op) {
   op->setAttr("lagrad_cache", UnitAttr::get(op->getContext()));
 }
 
-void populatePrimalCaches(LAGradContext &ctx, FuncOp primalFunc,
+void populatePrimalCaches(LAGradContext &ctx, func::FuncOp primalFunc,
                           ConversionPatternRewriter &rewriter) {
   for (auto tbrVal : ctx.toBeRecorded) {
     auto &op =
         *(tbrVal.getDefiningOp() ?: tbrVal.getParentRegion()->getParentOp());
-    if (op.getParentOfType<FuncOp>() != primalFunc) {
+    if (op.getParentOfType<func::FuncOp>() != primalFunc) {
       continue;
     }
     auto loc = op.getLoc();
@@ -39,8 +43,8 @@ void populatePrimalCaches(LAGradContext &ctx, FuncOp primalFunc,
     while (parent && !canAvoidCaching(parent)) {
       induction_vars.push_back(parent.getInductionVar());
       // Assume the step sizes are 1.
-      upper_bounds.push_back(parent.upperBound());
-      lower_bounds.push_back(parent.lowerBound());
+      upper_bounds.push_back(parent.getUpperBound());
+      lower_bounds.push_back(parent.getLowerBound());
       rewriter.setInsertionPoint(parent);
       parent = parent->getParentOfType<scf::ForOp>();
     }
@@ -96,12 +100,12 @@ void populatePrimalCaches(LAGradContext &ctx, FuncOp primalFunc,
       markAsCache(view);
       ctx.debug_names[view] =
           "<write view for caching " + ctx.debug_names[tbrVal] + ">";
-      auto memref = rewriter.create<memref::BufferCastOp>(
+      auto memref = rewriter.create<bufferization::ToMemrefOp>(
           loc, MemRefType::get(rtt.getShape(), rtt.getElementType()), tbrVal);
       markAsCache(memref);
       ctx.debug_names[memref] =
           "<casted memref for writing " + ctx.debug_names[tbrVal] + ">";
-      markAsCache(rewriter.create<linalg::CopyOp>(loc, memref, view));
+      markAsCache(rewriter.create<linalg::CopyOp>(loc, ValueRange{memref.getResult()}, ValueRange{view.getResult()}));
       ctx.tbrCachedVals[tbrVal] = cache;
     } else {
       auto cache = rewriter.create<memref::AllocOp>(

--- a/lib/LAGrad/SCFVectorJacobianProducts.cpp
+++ b/lib/LAGrad/SCFVectorJacobianProducts.cpp
@@ -1,4 +1,11 @@
 #include "LAGrad/Utils.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Bufferization/IR/Bufferization.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Transforms/DialectConversion.h"
 
 namespace mlir {
 using namespace mlir;
@@ -29,8 +36,8 @@ void DEPRECATEDpopulatePrimalCache(
   rewriter.setInsertionPoint(forOp);
   auto cacheSize =
       rewriter
-          .create<arith::SubIOp>(forOp.getLoc(), forOp.upperBound(),
-                                 forOp.lowerBound())
+          .create<arith::SubIOp>(forOp.getLoc(), forOp.getUpperBound(),
+                                 forOp.getLowerBound())
           .getResult();
 
   SmallVector<Value> caches;
@@ -72,28 +79,24 @@ void DEPRECATEDpopulatePrimalCache(
       auto intToAttr = [&](int64_t i) {
         return IntegerAttr::get(IntegerType::get(ctx, 64), i);
       };
-      SmallVector<Attribute> staticOffsets{
-          IntegerAttr::get(IntegerType::get(ctx, 64), -9223372036854775808ULL)};
-      SmallVector<Attribute> staticSizes{intToAttr(1)};
-      SmallVector<Attribute> staticStrides{intToAttr(1)};
+      SmallVector<int64_t> staticOffsets{ShapedType::kDynamic};
+      SmallVector<int64_t> staticSizes{1};
+      SmallVector<int64_t> staticStrides{1};
       for (int i = 0; i < tensorType.getRank(); i++) {
-        staticOffsets.push_back(intToAttr(0));
-        staticSizes.push_back(intToAttr(tensorType.getShape()[i]));
-        staticStrides.push_back(intToAttr(1));
+        staticOffsets.push_back(0);
+        staticSizes.push_back(tensorType.getShape()[i]);
+        staticStrides.push_back(1);
       }
-      auto staticOffset = ArrayAttr::get(ctx, staticOffsets);
-      auto staticSize = ArrayAttr::get(ctx, staticSizes);
-      auto staticStride = ArrayAttr::get(ctx, staticStrides);
       auto view = rewriter.create<memref::SubViewOp>(
           valToCache.getLoc(), resultType, ccache,
-          /*dynamic shapes=*/ValueRange(forOp.getInductionVar()), ValueRange(),
+          /*dynamic offsets=*/ValueRange(forOp.getInductionVar()), ValueRange(),
           ValueRange(),
-          /*staticShapes=*/staticOffset, staticSize, staticStride);
-      auto memref = rewriter.create<memref::BufferCastOp>(
+          /*static shapes=*/staticOffsets, staticSizes, staticStrides);
+      auto memref = rewriter.create<bufferization::ToMemrefOp>(
           valToCache.getLoc(),
           MemRefType::get(tensorType.getShape(), tensorType.getElementType()),
           valToCache);
-      rewriter.create<linalg::CopyOp>(valToCache.getLoc(), memref, view);
+      rewriter.create<linalg::CopyOp>(valToCache.getLoc(), ValueRange{memref.getResult()}, ValueRange{view.getResult()});
     } else {
       rewriter.create<memref::StoreOp>(valToCache.getLoc(), valToCache, ccache,
                                        forOp.getInductionVar());
@@ -108,7 +111,7 @@ void reverseForOpV2(scf::ForOp forOp, LAGradContext &ctx,
                     ConversionPatternRewriter &rewriter) {
   PatternRewriter::InsertionGuard insertionGuard(rewriter);
   // Record the ops to clone before augmenting the primal with the caches.
-  auto primalOps = forOp.getLoopBody().getOps();
+  auto& primalOps = forOp.getBody()->getOperations();
   SmallVector<Value> operandsWithIV{
       forOp.getInductionVar(),
       // This is only valid under certain conditions, i.e. if the result was
@@ -121,9 +124,9 @@ void reverseForOpV2(scf::ForOp forOp, LAGradContext &ctx,
   // By construction, free operands come before iter arg grads, which is a
   // little awkward.
   SmallVector<Value> inputOperands{free_operands};
-  inputOperands.reserve(free_operands.size() + forOp.getNumIterOperands());
-  for (size_t i = 0; i < forOp.getNumIterOperands(); i++) {
-    auto iterOperand = forOp.getIterOperands()[i];
+  inputOperands.reserve(free_operands.size() + forOp.getNumRegionIterArgs());
+  for (size_t i = 0; i < forOp.getNumRegionIterArgs(); i++) {
+    auto iterOperand = forOp.getInitArgs()[i];
     if (isFloatOrFloatTensor(iterOperand.getType()) && i != result_idx) {
       inputOperands.push_back(iterOperand);
     }
@@ -144,12 +147,12 @@ void reverseForOpV2(scf::ForOp forOp, LAGradContext &ctx,
 
   DenseMap<Value, Value> oldToCloned;
   auto adjointFor = rewriter.create<scf::ForOp>(
-      forOp.getLoc(), forOp.lowerBound(), forOp.upperBound(), forOp.step(),
+      forOp.getLoc(), forOp.getLowerBound(), forOp.getUpperBound(), forOp.getStep(),
       iterArgsInit,
       [&](OpBuilder &builder, Location loc, Value iv, ValueRange iterArgs) {
-        Value idx = builder.create<arith::SubIOp>(loc, forOp.upperBound(), iv);
+        Value idx = builder.create<arith::SubIOp>(loc, forOp.getUpperBound(), iv);
         Value one = builder.create<arith::ConstantIndexOp>(loc, 1);
-        idx = builder.create<arith::AddIOp>(loc, idx, forOp.lowerBound());
+        idx = builder.create<arith::AddIOp>(loc, idx, forOp.getLowerBound());
         idx = builder.create<arith::SubIOp>(loc, idx, one);
         SmallVector<Value> regionArgs;
         regionArgs.push_back(idx);
@@ -214,13 +217,13 @@ void reverseForOpV2(scf::ForOp forOp, LAGradContext &ctx,
               ctx.debug_names[view] =
                   "<read view for caching " + ctx.debug_names[tbrVal] + ">";
               auto casted = builder.create<memref::CastOp>(
-                  loc, view.getResult(),
-                  MemRefType::get(rtt.getShape(), rtt.getElementType()));
+                  loc, MemRefType::get(rtt.getShape(), rtt.getElementType()),
+                  view.getResult());
               markAsCache(casted, ctx.debug_names[tbrVal]);
               ctx.debug_names[casted] =
                   "<casted memref for reading " + ctx.debug_names[tbrVal] + ">";
               auto loaded =
-                  builder.create<memref::TensorLoadOp>(loc, casted.getResult());
+                  builder.create<bufferization::ToTensorOp>(loc, casted.getResult());
               markAsCache(loaded, ctx.debug_names[tbrVal]);
               ctx.debug_names[loaded] =
                   "<loaded tensor from cached " + ctx.debug_names[tbrVal] + ">";
@@ -239,7 +242,7 @@ void reverseForOpV2(scf::ForOp forOp, LAGradContext &ctx,
         // Clone ops that don't depend on the region iter args
         for (auto &pop : primalOps) {
           if (!pop.hasAttr("lagrad_cache") && pop.getNumResults() > 0) {
-            SmallVector<Value> frontier{pop.getResults()};
+            SmallVector<Value> frontier(pop.getResults().begin(), pop.getResults().end());
             ValueSet deps;
             runBottomUpDFS(frontier, deps);
             auto inDependSet = [&](Value v) { return deps.contains(v); };
@@ -281,14 +284,14 @@ void reverseForOpV2(scf::ForOp forOp, LAGradContext &ctx,
         for (auto iterArg : forOp.getRegionIterArgs()) {
           // TODO: stop treating the result as a special case
           if (iterArg ==
-              forOp.getRegionIterArgForOpOperand(
-                  forOp.getOpOperandForResult(forOp.results()[result_idx]))) {
+              forOp.getTiedLoopResult(
+                  forOp.getTiedLoopInit(forOp.getResults()[result_idx]))) {
             vjp_op = iterArg;
           } else if (isFloatOrFloatTensor(iterArg.getType())) {
             // Need to map again from gradient spaces from op operands to iter
             // args. This definitely feels brittle and should be cleaned up.
-            env[iterArg] =
-                env[forOp.getOpOperandForRegionIterArg(iterArg).get()];
+            OpOperand *tiedOperand = forOp.getTiedLoopInit(iterArg);
+            env[iterArg] = env[tiedOperand->get()];
             inputRegionArgs.push_back(iterArg);
           }
         }
@@ -361,7 +364,7 @@ void reverseForOpV2(scf::ForOp forOp, LAGradContext &ctx,
   // The output argument is a special case here. The gradient of the primal
   // result should always be the first adjoint result by construction.
   // TODO: Change this
-  outer_env[forOp.getIterOperands()[result_idx]] = adjointFor.getResult(0);
+  outer_env[forOp.getInitArgs()[result_idx]] = adjointFor.getResult(0);
   for (auto result_pair :
        llvm::zip(inputOperands, adjointFor.getResults().drop_front(1))) {
     auto free_operand = std::get<0>(result_pair);
@@ -379,7 +382,7 @@ void reverseForOpV1(scf::ForOp forOp, LAGradContext &ctx,
   forOp.emitWarning() << "Using old style scf.for differentiation";
   PatternRewriter::InsertionGuard insertionGuard(rewriter);
   // Record the ops to clone before augmenting the primal with the caches.
-  auto primalOps = forOp.getLoopBody().getOps();
+  auto& primalOps = forOp.getBody()->getOperations();
   SmallVector<std::pair<Value, Value>> iterArgsToCached;
   DEPRECATEDpopulatePrimalCache(forOp, rewriter, iterArgsToCached);
   SmallVector<Value> operandsWithIV{
@@ -394,9 +397,9 @@ void reverseForOpV1(scf::ForOp forOp, LAGradContext &ctx,
   // By construction, free operands come before iter arg grads, which is a
   // little awkward.
   SmallVector<Value> inputOperands{free_operands};
-  inputOperands.reserve(free_operands.size() + forOp.getNumIterOperands());
-  for (size_t i = 0; i < forOp.getNumIterOperands(); i++) {
-    auto iterOperand = forOp.getIterOperands()[i];
+  inputOperands.reserve(free_operands.size() + forOp.getNumRegionIterArgs());
+  for (size_t i = 0; i < forOp.getNumRegionIterArgs(); i++) {
+    auto iterOperand = forOp.getInitArgs()[i];
     if (isFloatOrFloatTensor(iterOperand.getType()) && i != result_idx) {
       inputOperands.push_back(iterOperand);
     }
@@ -411,13 +414,13 @@ void reverseForOpV1(scf::ForOp forOp, LAGradContext &ctx,
     iterArgsInit.push_back(space);
   }
   auto adjointFor = rewriter.create<scf::ForOp>(
-      forOp.getLoc(), forOp.lowerBound(), forOp.upperBound(), forOp.step(),
+      forOp.getLoc(), forOp.getLowerBound(), forOp.getUpperBound(), forOp.getStep(),
       iterArgsInit,
       [&](OpBuilder &builder, Location loc, Value iv, ValueRange iterArgs) {
         SmallVector<Value> regionArgs;
-        Value idx = builder.create<arith::SubIOp>(loc, forOp.upperBound(), iv);
+        Value idx = builder.create<arith::SubIOp>(loc, forOp.getUpperBound(), iv);
         Value one = builder.create<arith::ConstantIndexOp>(loc, 1);
-        idx = builder.create<arith::AddIOp>(loc, idx, forOp.lowerBound());
+        idx = builder.create<arith::AddIOp>(loc, idx, forOp.getLowerBound());
         idx = builder.create<arith::SubIOp>(loc, idx, one);
         regionArgs.push_back(idx);
         regionArgs.push_back(forOp.getResult(result_idx));
@@ -437,26 +440,19 @@ void reverseForOpV1(scf::ForOp forOp, LAGradContext &ctx,
               return IntegerAttr::get(
                   IntegerType::get(builder.getContext(), 64), i);
             };
-            SmallVector<Attribute> staticOffsets{
-                IntegerAttr::get(IntegerType::get(builder.getContext(), 64),
-                                 -9223372036854775808ULL)};
-            SmallVector<Attribute> staticSizes{intToAttr(1)};
-            SmallVector<Attribute> staticStrides{intToAttr(1)};
+            SmallVector<int64_t> staticOffsets{ShapedType::kDynamic};
+            SmallVector<int64_t> staticSizes{1};
+            SmallVector<int64_t> staticStrides{1};
             for (int i = 0; i < tensorType.getRank(); i++) {
-              staticOffsets.push_back(intToAttr(0));
-              staticSizes.push_back(intToAttr(tensorType.getShape()[i]));
-              staticStrides.push_back(intToAttr(1));
+              staticOffsets.push_back(0);
+              staticSizes.push_back(tensorType.getShape()[i]);
+              staticStrides.push_back(1);
             }
-            auto staticOffset =
-                ArrayAttr::get(builder.getContext(), staticOffsets);
-            auto staticSize = ArrayAttr::get(builder.getContext(), staticSizes);
-            auto staticStride =
-                ArrayAttr::get(builder.getContext(), staticStrides);
 
             auto view = builder.create<memref::SubViewOp>(
                 cpair.second.getLoc(), resultType, cpair.second,
-                /*dynamic shapes=*/ValueRange(idx), ValueRange(), ValueRange(),
-                /*staticShapes=*/staticOffset, staticSize, staticStride);
+                /*dynamic offsets=*/ValueRange(idx), ValueRange(), ValueRange(),
+                /*static shapes=*/staticOffsets, staticSizes, staticStrides);
 
             constexpr bool alloc_new = false;
             if (alloc_new) {
@@ -465,17 +461,18 @@ void reverseForOpV1(scf::ForOp forOp, LAGradContext &ctx,
                   MemRefType::get(tensorType.getShape(),
                                   tensorType.getElementType()));
               builder.create<linalg::CopyOp>(cpair.second.getLoc(),
-                                             view.getResult(), dest);
+                                             ValueRange{view.getResult()}, ValueRange{dest.getResult()});
 
-              loaded = builder.create<memref::TensorLoadOp>(
+              loaded = builder.create<bufferization::ToTensorOp>(
                   cpair.second.getLoc(), dest.getResult());
             } else {
               // I don't know that this is always safe
               auto casted = builder.create<memref::CastOp>(
-                  cpair.second.getLoc(), view.getResult(),
+                  cpair.second.getLoc(),
                   MemRefType::get(tensorType.getShape(),
-                                  tensorType.getElementType()));
-              loaded = builder.create<memref::TensorLoadOp>(
+                                  tensorType.getElementType()),
+                  view.getResult());
+              loaded = builder.create<bufferization::ToTensorOp>(
                   cpair.second.getLoc(), casted.getResult());
             }
           } else {
@@ -486,8 +483,8 @@ void reverseForOpV1(scf::ForOp forOp, LAGradContext &ctx,
           // This is to fix the case where the vjp value must be updated in the
           // body of the adjoint loop. TODO: This might not work with vectors
           if (cpair.first ==
-              forOp.getRegionIterArgForOpOperand(
-                  forOp.getOpOperandForResult(forOp.results()[result_idx]))) {
+              forOp.getTiedLoopResult(
+                  forOp.getTiedLoopInit(forOp.getResults()[result_idx]))) {
             vjp_op = loaded;
           } else if (isFloatOrFloatTensor(loaded.getType())) {
             replacedPrimalIterArgs.push_back(loaded);
@@ -495,7 +492,7 @@ void reverseForOpV1(scf::ForOp forOp, LAGradContext &ctx,
           regionArgs.push_back(loaded);
         }
         auto primalRegionOps = cloneBasicBlock(
-            primalOps, builder, /*new=*/regionArgs, /*old=*/operandsWithIV,
+            llvm::make_range(forOp.getRegion().op_begin(), forOp.getRegion().op_end()), builder, /*new=*/regionArgs, /*old=*/operandsWithIV,
             /*offsetInputs=*/false, &ctx);
 
         DenseMap<Value, Value> env;
@@ -570,7 +567,7 @@ void reverseForOpV1(scf::ForOp forOp, LAGradContext &ctx,
 
   // The output argument is a special case here. The gradient of the primal
   // result should always be the first adjoint result by construction.
-  outer_env[forOp.getIterOperands()[result_idx]] = adjointFor.getResult(0);
+  outer_env[forOp.getInitArgs()[result_idx]] = adjointFor.getResult(0);
   for (auto result_pair :
        llvm::zip(inputOperands, adjointFor.getResults().drop_front(1))) {
     auto free_operand = std::get<0>(result_pair);
@@ -606,9 +603,9 @@ Value reverseIfOpV2(scf::IfOp ifOp, LAGradContext &ctx, Value freeOperand,
     return [&](OpBuilder &builder, Location loc) {
       PatternRewriter::InsertionGuard insertionGuard(rewriter);
       // Clone ops that don't depend on the region iter args
-      for (auto &pop : ifRegion.getOps()) {
+      for (auto &pop : ifRegion.front().getOperations()) {
         if (pop.getNumResults() > 0) {
-          SmallVector<Value> frontier{pop.getResults()};
+          SmallVector<Value> frontier(pop.getResults().begin(), pop.getResults().end());
           ValueSet deps;
           runBottomUpDFS(frontier, deps);
           auto inDependSet = [&](Value v) { return deps.contains(v); };
@@ -626,7 +623,7 @@ Value reverseIfOpV2(scf::IfOp ifOp, LAGradContext &ctx, Value freeOperand,
 
       DenseMap<Value, Value> env;
       SmallVector<Operation *> reversedPrimalOps;
-      for (auto &pop : ifRegion.getOps()) {
+      for (auto &pop : ifRegion.front().getOperations()) {
         reversedPrimalOps.push_back(&pop);
       }
 
@@ -653,10 +650,20 @@ Value reverseIfOpV2(scf::IfOp ifOp, LAGradContext &ctx, Value freeOperand,
     };
   };
   auto adjointIf = rewriter.create<scf::IfOp>(
-      ifOp->getLoc(), /*resultTypes=*/freeOperand.getType(),
-      /*cond=*/ifOp.condition(),
-      /*thenBuilder=*/reverseIfBlock(ifOp.thenRegion()),
-      /*elseBuilder=*/reverseIfBlock(ifOp.elseRegion()));
+      ifOp->getLoc(), /*resultTypes=*/TypeRange{freeOperand.getType()},
+      /*cond=*/ifOp.getCondition(), /*withElseRegion=*/true);
+  {
+    OpBuilder::InsertionGuard guard(rewriter);
+    rewriter.setInsertionPointToStart(adjointIf.thenBlock());
+    auto thenBuilder = reverseIfBlock(ifOp.getThenRegion());
+    thenBuilder(rewriter, ifOp->getLoc());
+  }
+  {
+    OpBuilder::InsertionGuard guard(rewriter);
+    rewriter.setInsertionPointToStart(adjointIf.elseBlock());
+    auto elseBuilder = reverseIfBlock(ifOp.getElseRegion());
+    elseBuilder(rewriter, ifOp->getLoc());
+  }
   // Replace ops referring to the old arguments to the new operands
   adjointIf.walk([&](Operation *op) {
     for (size_t i = 0; i < op->getNumOperands(); i++)
@@ -672,7 +679,7 @@ Value reverseIfOpV1(scf::IfOp ifOp, LAGradContext &ctx, Value freeOperand,
   auto reverseIfBlock = [&](Region &ifRegion) {
     return [&](OpBuilder &builder, Location loc) {
       PatternRewriter::InsertionGuard insertionGuard(rewriter);
-      auto primalRegionOps = cloneBasicBlock(ifRegion.getOps(), builder, {}, {},
+      auto primalRegionOps = cloneBasicBlock(llvm::make_range(ifRegion.op_begin(), ifRegion.op_end()), builder, {}, {},
                                              /*offsetInputs=*/false, &ctx);
       DenseMap<Value, Value> env;
       for (auto it = primalRegionOps.rbegin(); it != primalRegionOps.rend();
@@ -698,10 +705,20 @@ Value reverseIfOpV1(scf::IfOp ifOp, LAGradContext &ctx, Value freeOperand,
   };
 
   auto adjointIf = rewriter.create<scf::IfOp>(
-      ifOp->getLoc(), /*resultTypes=*/freeOperand.getType(),
-      /*cond=*/ifOp.condition(),
-      /*thenBuilder=*/reverseIfBlock(ifOp.thenRegion()),
-      /*elseBuilder=*/reverseIfBlock(ifOp.elseRegion()));
+      ifOp->getLoc(), /*resultTypes=*/TypeRange{freeOperand.getType()},
+      /*cond=*/ifOp.getCondition(), /*withElseRegion=*/true);
+  {
+    OpBuilder::InsertionGuard guard(rewriter);
+    rewriter.setInsertionPointToStart(adjointIf.thenBlock());
+    auto thenBuilder = reverseIfBlock(ifOp.getThenRegion());
+    thenBuilder(rewriter, ifOp->getLoc());
+  }
+  {
+    OpBuilder::InsertionGuard guard(rewriter);
+    rewriter.setInsertionPointToStart(adjointIf.elseBlock());
+    auto elseBuilder = reverseIfBlock(ifOp.getElseRegion());
+    elseBuilder(rewriter, ifOp->getLoc());
+  }
   return adjointIf.getResult(0);
 }
 

--- a/lib/LAGrad/SparsePropagation.cpp
+++ b/lib/LAGrad/SparsePropagation.cpp
@@ -1,10 +1,15 @@
 #include "LAGrad/Analysis.h"
 #include "LAGrad/Passes.h"
 #include "LAGrad/Utils.h"
-#include "mlir/Dialect/Linalg/IR/LinalgOps.h"
-#include "mlir/Dialect/SCF/SCF.h"
+#include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Bufferization/IR/Bufferization.h"
+#include "mlir/Dialect/Bufferization/Transforms/Bufferize.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
-#include "mlir/Transforms/Bufferize.h"
 #include "mlir/Transforms/DialectConversion.h"
 #include "mlir/Transforms/Passes.h"
 #include "llvm/Support/raw_ostream.h"
@@ -30,13 +35,13 @@ inline raw_ostream &operator<<(raw_ostream &os, HotSparsityType type) {
 }
 
 SparsePropagation::SparsePropagation(Operation *op, AnalysisManager &manager) {
-  // op->walk([&](FuncOp funcOp) { DEBUGpopulateFunc(debug_names, funcOp); });
-  op->walk([&](FuncOp funcOp) {
+  // op->walk([&](func::FuncOp funcOp) { DEBUGpopulateFunc(debug_names, funcOp); });
+  op->walk([&](func::FuncOp funcOp) {
     for (BlockArgument arg : funcOp.getArguments()) {
       if (auto rankedTensorType = arg.getType().dyn_cast<RankedTensorType>()) {
         auto sparsityEncoding = getSparsityEncoding(rankedTensorType);
-        if (sparsityEncoding.hasValue()) {
-          sparsityTypes[arg] = sparsityEncoding.getValue();
+        if (sparsityEncoding.has_value()) {
+          sparsityTypes[arg] = sparsityEncoding.value();
         }
       }
     }
@@ -44,15 +49,15 @@ SparsePropagation::SparsePropagation(Operation *op, AnalysisManager &manager) {
 
   op->walk([&](linalg::FillOp fillOp) {
     if (auto floatOp = dyn_cast_or_null<arith::ConstantFloatOp>(
-            fillOp.value().getDefiningOp())) {
+            fillOp.getDpsInputOperand(0)->get().getDefiningOp())) {
       if (floatOp.value().isZero()) {
         this->sparsityTypes[fillOp.getResult(0)] = HotSparsityType::Empty;
       }
     }
   });
   op->walk([&](arith::ConstantOp constOp) {
-    if (auto valueAttr = constOp.valueAttr().dyn_cast<SplatElementsAttr>()) {
-      if (auto splatAttr = valueAttr.getSplatValue().dyn_cast<FloatAttr>()) {
+    if (auto valueAttr = constOp.getValueAttr().dyn_cast<SplatElementsAttr>()) {
+      if (auto splatAttr = valueAttr.getSplatValue<Attribute>().dyn_cast<FloatAttr>()) {
         if (splatAttr.getValue().isZero()) {
           sparsityTypes[constOp.getResult()] = HotSparsityType::Empty;
         }
@@ -63,8 +68,8 @@ SparsePropagation::SparsePropagation(Operation *op, AnalysisManager &manager) {
   op->walk<WalkOrder::PreOrder>([&](scf::ForOp forOp) {
     propagateSCFFor(forOp);
     auto maybeLoopNest = lnAnalysis.getLoopNest(forOp);
-    if (maybeLoopNest.hasValue()) {
-      propagateLoopNest(maybeLoopNest.getValue());
+    if (maybeLoopNest.has_value()) {
+      propagateLoopNest(maybeLoopNest.value());
     }
   });
   op->walk(
@@ -75,56 +80,56 @@ SparsePropagation::SparsePropagation(Operation *op, AnalysisManager &manager) {
 }
 
 // These getSparsityType functions the same name but very different functions
-Optional<HotSparsityType>
+std::optional<HotSparsityType>
 SparsePropagation::getSparsityEncoding(RankedTensorType type) const {
   if (auto encoding = type.getEncoding().dyn_cast_or_null<StringAttr>()) {
-    return StringSwitch<Optional<HotSparsityType>>(encoding.getValue())
+    return StringSwitch<std::optional<HotSparsityType>>(encoding.getValue())
         .Case("empty", HotSparsityType::Empty)
         .Case("onehot", HotSparsityType::OneHot)
         .Case("rowhot", HotSparsityType::RowHot)
         .Case("colhot", HotSparsityType::ColHot)
-        .Default(llvm::None);
+        .Default(std::nullopt);
   }
-  return llvm::None;
+  return std::nullopt;
 }
 
 void SparsePropagation::setIndices(Value tensor, Value indices) {
   this->indices[tensor] = indices;
 }
 
-Optional<Value> SparsePropagation::getIndices(Value tensor) {
-  return indices[tensor] ? Optional<Value>(indices[tensor]) : llvm::None;
+std::optional<Value> SparsePropagation::getIndices(Value tensor) {
+  return indices[tensor] ? std::optional<Value>(indices[tensor]) : std::nullopt;
 }
 
-Optional<HotSparsityType> SparsePropagation::getSparsityType(Value val) const {
+std::optional<HotSparsityType> SparsePropagation::getSparsityType(Value val) const {
   if (sparsityTypes.count(val) == 0) {
-    return llvm::None;
+    return std::nullopt;
   }
   return sparsityTypes.lookup(val);
 }
 
 void SparsePropagation::propagateInsertSlice(tensor::InsertSliceOp op) {
-  Optional<HotSparsityType> sourceSparsity = getSparsityType(op.source());
+  std::optional<HotSparsityType> sourceSparsity = getSparsityType(op.getSource());
 
-  if (!(sourceSparsity.hasValue() &&
-        sparsityTypes[op.dest()] == HotSparsityType::Empty)) {
+  if (!(sourceSparsity.has_value() &&
+        sparsityTypes[op.getDest()] == HotSparsityType::Empty)) {
     return;
   }
 
-  sparsityTypes[op.result()] = sourceSparsity.getValue();
+  sparsityTypes[op.getResult()] = sourceSparsity.value();
 }
 
 void SparsePropagation::propagateLinalgGeneric(linalg::GenericOp op) {
   // TODO: Reduce code duplication with sparse codegen
   auto isSparse = [this](OpOperand *operand) {
-    return getSparsityType(operand->get()).hasValue();
+    return getSparsityType(operand->get()).has_value();
   };
-  if (llvm::count_if(op.getInputOperands(), isSparse) != 1) {
+  if (llvm::count_if(op.getDpsInputOperands(), isSparse) != 1) {
     return;
   }
-  OpOperand *sparseOperand = *llvm::find_if(op.getInputOperands(), isSparse);
-  HotSparsityType spType = getSparsityType(sparseOperand->get()).getValue();
-  AffineMap sparseMap = op.getTiedIndexingMap(sparseOperand);
+  OpOperand *sparseOperand = *llvm::find_if(op.getDpsInputOperands(), isSparse);
+  HotSparsityType spType = getSparsityType(sparseOperand->get()).value();
+  AffineMap sparseMap = cast<AffineMapAttr>(op.getIndexingMaps()[sparseOperand->getOperandNumber()]).getValue();
   DenseSet<unsigned> sparseDims;
   switch (spType) {
   case HotSparsityType::OneHot:
@@ -144,8 +149,9 @@ void SparsePropagation::propagateLinalgGeneric(linalg::GenericOp op) {
     break;
   }
 
-  for (OpOperand *output : op.getOutputOperands()) {
-    AffineMap map = op.getTiedIndexingMap(output);
+  for (int64_t i = 0, e = op.getNumDpsInits(); i < e; ++i) {
+    OpOperand *output = op.getDpsInitOperand(i);
+    AffineMap map = cast<AffineMapAttr>(op.getIndexingMaps()[output->getOperandNumber()]).getValue();
     SmallVector<bool, 4> sparseMask;
     for (auto result : map.getResults()) {
       sparseMask.push_back(
@@ -162,11 +168,11 @@ void SparsePropagation::propagateLinalgGeneric(linalg::GenericOp op) {
 }
 
 void SparsePropagation::propagateSCFFor(scf::ForOp op) {
-  for (OpOperand &operand : op.getIterOpOperands()) {
+  for (OpOperand &operand : op.getInitArgsMutable()) {
     auto spType = getSparsityType(operand.get());
-    if (spType.hasValue()) {
-      sparsityTypes[op.getRegionIterArgForOpOperand(operand)] =
-          spType.getValue();
+    if (spType.has_value()) {
+      sparsityTypes[op.getTiedLoopResult(&operand)] =
+          spType.value();
     }
   }
 }
@@ -178,9 +184,9 @@ void SparsePropagation::propagateLoopNest(LoopNest loopNest) {
     Value inputOperand = loopNest.inputTensorOperands.front();
     auto spType = getSparsityType(inputOperand);
     auto destSpType = getSparsityType(loopNest.outputTensorOperands.front());
-    if (spType.hasValue() && spType.getValue() == HotSparsityType::OneHot &&
-        destSpType.hasValue() && destSpType == HotSparsityType::Empty) {
-      sparsityTypes[loopNest.results.front()] = spType.getValue();
+    if (spType.has_value() && spType.value() == HotSparsityType::OneHot &&
+        destSpType.has_value() && destSpType == HotSparsityType::Empty) {
+      sparsityTypes[loopNest.results.front()] = spType.value();
     }
   }
 }
@@ -195,12 +201,12 @@ RankedTensorType stripEncoding(RankedTensorType sourceType) {
                                sourceType.getElementType());
 }
 
-class SparsifyFuncOp : public OpConversionPattern<FuncOp> {
+class SparsifyFuncOp : public OpConversionPattern<func::FuncOp> {
 private:
   SparsePropagation &spAnalysis;
   bool hasRecognizedEncoding(Type type) const {
     if (auto rankedTensorType = type.dyn_cast<RankedTensorType>()) {
-      return spAnalysis.getSparsityEncoding(rankedTensorType).hasValue();
+      return spAnalysis.getSparsityEncoding(rankedTensorType).has_value();
     }
     return false;
   }
@@ -233,11 +239,11 @@ public:
         spAnalysis{spAnalysis} {}
 
   LogicalResult
-  matchAndRewrite(FuncOp op, ArrayRef<Value> operands,
+  matchAndRewrite(func::FuncOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     if (llvm::none_of(op.getArguments(), [this](BlockArgument arg) {
-          return spAnalysis.getSparsityType(arg).hasValue() &&
-                 !spAnalysis.getIndices(arg).hasValue();
+          return spAnalysis.getSparsityType(arg).has_value() &&
+                 !spAnalysis.getIndices(arg).has_value();
         })) {
       return failure();
     }
@@ -245,14 +251,14 @@ public:
     size_t idx = 0;
     auto *ctx = rewriter.getContext();
 
-    rewriter.updateRootInPlace(op, [&]() {
-      op.setType(stripEncodingFromFunc(op.getType()));
+    rewriter.modifyOpInPlace(op, [&]() {
+      op.setType(stripEncodingFromFunc(op.getFunctionType()));
       for (BlockArgument arg : op.getArguments()) {
         auto spType = spAnalysis.getSparsityType(arg);
-        if (spType.hasValue()) {
+        if (spType.has_value()) {
           auto addIndexArgument = [&]() {
             Type indicesType;
-            switch (spType.getValue()) {
+            switch (spType.value()) {
             case HotSparsityType::OneHot: {
               int64_t rank = arg.getType().cast<ShapedType>().getRank();
               if (rank == 1) {
@@ -275,7 +281,7 @@ public:
             auto argType = RankedTensorType::get(
                 originalArgType.getShape(), originalArgType.getElementType());
             arg.setType(argType);
-            op.insertArgument(idx + 1, indicesType, {});
+            op.insertArgument(idx + 1, indicesType, DictionaryAttr(), op.getLoc());
             spAnalysis.setIndices(arg, op.getArgument(idx + 1));
           };
           addIndexArgument();
@@ -293,37 +299,37 @@ public:
 bool matchSparsifyForOp(scf::ForOp op, SparsePropagation &spAnalysis,
                         LoopNestAnalysis &lnAnalysis) {
   auto maybeLoopNest = lnAnalysis.getLoopNest(op);
-  if (!maybeLoopNest.hasValue()) {
+  if (!maybeLoopNest.has_value()) {
     return false;
   }
-  LoopNest loopNest = maybeLoopNest.getValue();
+  LoopNest loopNest = maybeLoopNest.value();
   return llvm::any_of(loopNest.inputTensorOperands, [&spAnalysis](Value val) {
     auto spType = spAnalysis.getSparsityType(val);
-    return spType.hasValue() && spType.getValue() != HotSparsityType::Empty;
+    return spType.has_value() && spType.value() != HotSparsityType::Empty;
   });
 }
 
 bool matchSparsifyGenericOp(linalg::GenericOp op,
                             SparsePropagation &spAnalysis) {
   bool hasEncoding =
-      llvm::any_of(op.getInputOperands(), [&spAnalysis](OpOperand *operand) {
+      llvm::any_of(op.getDpsInputOperands(), [&spAnalysis](OpOperand *operand) {
         auto spType = spAnalysis.getSparsityType(operand->get());
-        return spType.hasValue() && spType.getValue() != HotSparsityType::Empty;
+        return spType.has_value() && spType.value() != HotSparsityType::Empty;
       });
   // TODO: potentially dangerous to not use this. We currently need it to match
   // a matmul in hand tracking because the zero value is propagated through loop
   // iter args.
 
   // bool outputIsZero =
-  //     op.getNumOutputs() == 1 &&
+  //     op.getNumDpsInits() == 1 &&
   //     spAnalysis
-  //             .getSparsityType(op.getOutputOperand(0)->get())
+  //             .getSparsityType(op.getDpsInitOperand(0)->get())
   //             // We need this to just be a sparsity type other than empty.
   //             .getValueOr(HotSparsityType::OneHot) == HotSparsityType::Empty;
   // if (op->hasAttr("debugme")) {
   //   errs() << "debugme found. Output is zero: " << outputIsZero << "\n";
-  //   for (OpOperand *operand : op.getInputOperands()) {
-  //     if (spAnalysis.getSparsityType(operand->get()).hasValue()) {
+  //   for (OpOperand *operand : op.getDpsInputOperands()) {
+  //     if (spAnalysis.getSparsityType(operand->get()).has_value()) {
   //       errs() << "operand is sparse: "
   //              << spAnalysis.getSparsityType(operand->get()).getValue() <<
   //              "\n";
@@ -341,14 +347,14 @@ SmallVector<Value> convertIndicesToValues(Location loc, Value memrefIndices,
   }
   Value zero = builder.create<arith::ConstantIndexOp>(loc, 0);
   Value one = builder.create<arith::ConstantIndexOp>(loc, 1);
-  return {builder.create<memref::LoadOp>(loc, memrefIndices, zero),
-          builder.create<memref::LoadOp>(loc, memrefIndices, one)};
+  return {builder.create<memref::LoadOp>(loc, memrefIndices, ValueRange{zero}),
+          builder.create<memref::LoadOp>(loc, memrefIndices, ValueRange{one})};
 }
 
 Value inlineRegion(linalg::GenericOp op, ValueRange indexedValues,
                    OpBuilder &builder) {
   auto &block = op->getRegion(0).front();
-  BlockAndValueMapping map;
+  IRMapping map;
   map.map(block.getArguments(), indexedValues);
   for (auto &op : block.without_terminator()) {
     auto *newOp = builder.clone(op, map);
@@ -373,16 +379,16 @@ static SmallVector<Value> makeCanonicalAffineApplies(OpBuilder &b, Location loc,
   for (auto e : map.getResults()) {
     auto exprMap = AffineMap::get(dims, map.getNumSymbols(), e);
     SmallVector<Value> operands(vals.begin(), vals.end());
-    canonicalizeMapAndOperands(&exprMap, &operands);
-    res.push_back(b.create<AffineApplyOp>(loc, exprMap, operands));
+    affine::canonicalizeMapAndOperands(&exprMap, &operands);
+    res.push_back(b.create<affine::AffineApplyOp>(loc, exprMap, operands));
   }
   return res;
 }
 
 static Value getSizeOfLoop(OpBuilder &b, linalg::LinalgOp op,
                            unsigned position) {
-  for (OpOperand *operand : op.getInputAndOutputOperands()) {
-    AffineMap map = op.getTiedIndexingMap(operand);
+  for (OpOperand *operand : op.getDpsInputOperands()) {
+    AffineMap map = cast<AffineMapAttr>(op.getIndexingMaps()[operand->getOperandNumber()]).getValue();
     if (map.isFunctionOfDim(position)) {
       for (auto pair : llvm::enumerate(map.getResults())) {
         if (pair.value().isFunctionOfDim(position) &&
@@ -403,7 +409,7 @@ private:
 
   Value allocateOutputSpace(Value tensor, Location loc, OpBuilder &b) const {
     RankedTensorType resultType = tensor.getType().cast<RankedTensorType>();
-    BufferizeTypeConverter typeConverter;
+    TypeConverter typeConverter;
     SmallVector<Value> dynamicSizes;
     dynamicSizes.reserve(resultType.getNumDynamicDims());
     for (unsigned idx = 0; idx < resultType.getRank(); idx++) {
@@ -422,21 +428,21 @@ public:
       : OpConversionPattern(ctx, /*benefit=*/1),
         spAnalysis{spAnalysis}, disabled{disabled} {}
   LogicalResult
-  matchAndRewrite(linalg::GenericOp op, ArrayRef<Value> operands,
+  matchAndRewrite(linalg::GenericOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     if (disabled || !matchSparsifyGenericOp(op, spAnalysis)) {
       return failure();
     }
     auto isSparse = [this](OpOperand *operand) {
-      return spAnalysis.getSparsityType(operand->get()).hasValue();
+      return spAnalysis.getSparsityType(operand->get()).has_value();
     };
-    OpOperand *sparseOperand = *llvm::find_if(op.getInputOperands(), isSparse);
-    assert(llvm::count_if(op.getInputOperands(), isSparse) == 1 &&
+    OpOperand *sparseOperand = *llvm::find_if(op.getDpsInputOperands(), isSparse);
+    assert(llvm::count_if(op.getDpsInputOperands(), isSparse) == 1 &&
            "Expected exactly 1 operand to have hot sparsity type (not yet "
            "implemented)");
     HotSparsityType spType =
-        spAnalysis.getSparsityType(sparseOperand->get()).getValue();
-    AffineMap sparseMap = op.getTiedIndexingMap(sparseOperand);
+        spAnalysis.getSparsityType(sparseOperand->get()).value();
+    AffineMap sparseMap = cast<AffineMapAttr>(op.getIndexingMaps()[sparseOperand->getOperandNumber()]).getValue();
     DenseSet<unsigned> sparseDims;
     switch (spType) {
     case HotSparsityType::OneHot:
@@ -457,17 +463,17 @@ public:
     }
     SmallVector<Value, 4> lbs, ubs, steps;
     Location loc = op.getLoc();
-    BufferizeTypeConverter typeConverter;
+    TypeConverter typeConverter;
     Value zero = rewriter.create<arith::ConstantOp>(
         loc,
-        FloatAttr::get(op.getOutputTensorTypes()[0].getElementType(), 0.0));
+        FloatAttr::get(op.getDpsInits().getTypes()[0].cast<ShapedType>().getElementType(), 0.0));
     Value idxZero = rewriter.create<arith::ConstantIndexOp>(loc, 0);
     Value idxOne = rewriter.create<arith::ConstantIndexOp>(loc, 1);
-    // Value space = rewriter.create<memref::BufferCastOp>(
-    //     loc, typeConverter.convertType(op.getOutputTensorTypes()[0]),
-    //     op.getOutputOperand(0)->get());
+    // Value space = rewriter.create<bufferization::ToMemrefOp>(
+    //     loc, typeConverter.convertType(op.getDpsInits().getTypes()[0]),
+    //     op.getDpsInitOperand(0)->get());
     Value space =
-        allocateOutputSpace(op.getOutputOperand(0)->get(), loc, rewriter);
+        allocateOutputSpace(op.getDpsInitOperand(0)->get(), loc, rewriter);
     rewriter.create<linalg::FillOp>(loc, zero, space);
     for (unsigned dim = 0; dim < sparseMap.getNumDims(); dim++) {
       if (!sparseDims.contains(dim)) {
@@ -477,8 +483,8 @@ public:
       }
     }
 
-    Optional<Value> sparseIndices = spAnalysis.getIndices(sparseOperand->get());
-    if (!sparseIndices.hasValue()) {
+    std::optional<Value> sparseIndices = spAnalysis.getIndices(sparseOperand->get());
+    if (!sparseIndices.has_value()) {
       op.emitError() << "sparse op was missing indices\n";
       return failure();
     }
@@ -487,11 +493,11 @@ public:
     // operand, hence the null value in the col-hot case.
     SmallVector<Value> sparseIvs =
         spType == HotSparsityType::OneHot
-            ? ValueRange{convertIndicesToValues(loc, sparseIndices.getValue(),
+            ? ValueRange{convertIndicesToValues(loc, sparseIndices.value(),
                                                 rewriter)}
         : spType == HotSparsityType::ColHot
-            ? ValueRange{Value(), sparseIndices.getValue()}
-            : ValueRange{sparseIndices.getValue()};
+            ? ValueRange{Value(), sparseIndices.value()}
+            : ValueRange{sparseIndices.value()};
 
     scf::buildLoopNest(
         rewriter, loc, lbs, ubs, steps,
@@ -514,28 +520,29 @@ public:
           }
 
           SmallVector<Value, 3> indexedValues;
-          indexedValues.reserve(op.getNumInputsAndOutputs());
+          indexedValues.reserve(op.getNumDpsInputs() + op.getNumDpsInits());
           // Emit reads to input and output views
-          for (OpOperand *operand : op.getInputAndOutputOperands()) {
+          for (OpOperand *operand : op.getDpsInputOperands()) {
             indexedValues.push_back(builder.create<tensor::ExtractOp>(
                 loc, operand->get(),
                 makeCanonicalAffineApplies(
-                    builder, loc, op.getTiedIndexingMap(operand), allIvs)));
+                    builder, loc, cast<AffineMapAttr>(op.getIndexingMaps()[operand->getOperandNumber()]).getValue(), allIvs)));
           }
           // Inline region and emit store
           Value toStore = inlineRegion(op, indexedValues, builder);
           builder.create<memref::StoreOp>(
               loc, toStore, space,
               makeCanonicalAffineApplies(
-                  builder, loc, op.getTiedIndexingMap(op.getOutputOperand(0)),
+                  builder, loc, cast<AffineMapAttr>(op.getIndexingMaps()[op.getDpsInitOperand(0)->getOperandNumber()]).getValue(),
                   allIvs));
         });
-    rewriter.replaceOpWithNewOp<memref::TensorLoadOp>(op, space);
+    rewriter.replaceOpWithNewOp<bufferization::ToTensorOp>(op, space);
 
     // propagate sparse indices
-    for (OpOperand *outOperand : op.getOutputOperands()) {
+    for (int64_t i = 0, e = op.getNumDpsInits(); i < e; ++i) {
+      OpOperand *outOperand = op.getDpsInitOperand(i);
       SmallVector<Value, 2> newSparseIdxVals;
-      AffineMap outMap = op.getTiedIndexingMap(outOperand);
+      AffineMap outMap = cast<AffineMapAttr>(op.getIndexingMaps()[outOperand->getOperandNumber()]).getValue();
       for (auto result : outMap.getResults()) {
         unsigned dim = result.cast<AffineDimExpr>().getPosition();
         if (sparseDims.contains(dim)) {
@@ -574,22 +581,22 @@ private:
   LoopNestAnalysis &lnAnalysis;
 
   void stripEncodingFromLoop(scf::ForOp op) const {
-    for (OpOperand &operand : op.getIterOpOperands()) {
-      BlockArgument arg = op.getRegionIterArgForOpOperand(operand);
-      OpResult result = op.getResultForOpOperand(operand);
+    for (OpOperand &operand : op.getInitArgsMutable()) {
+      BlockArgument arg = op.getTiedLoopRegionIterArg(&operand);
+      OpResult result = op.getTiedLoopResult(&operand);
 
       if (auto rankedTensorType = arg.getType().dyn_cast<RankedTensorType>()) {
-        if (spAnalysis.getSparsityEncoding(rankedTensorType).hasValue()) {
+        if (spAnalysis.getSparsityEncoding(rankedTensorType).has_value()) {
           arg.setType(stripEncoding(rankedTensorType));
           result.setType(stripEncoding(rankedTensorType));
         }
       }
     }
-    for (Operation &op : op.getLoopBody().getOps()) {
+    for (Operation &op : op.getBody()->getOperations()) {
       for (OpResult result : op.getResults()) {
         if (auto rankedTensorType =
                 result.getType().dyn_cast<RankedTensorType>()) {
-          if (spAnalysis.getSparsityEncoding(rankedTensorType).hasValue()) {
+          if (spAnalysis.getSparsityEncoding(rankedTensorType).has_value()) {
             result.setType(stripEncoding(rankedTensorType));
           }
         }
@@ -604,23 +611,23 @@ public:
         lnAnalysis{lnAnalysis} {}
 
   LogicalResult
-  matchAndRewrite(scf::ForOp op, ArrayRef<Value> operands,
+  matchAndRewrite(scf::ForOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     if (!matchSparsifyForOp(op, spAnalysis, lnAnalysis)) {
       return failure();
     }
-    LoopNest loopNest = lnAnalysis.getLoopNest(op).getValue();
+    LoopNest loopNest = lnAnalysis.getLoopNest(op).value();
 
     if (loopNest.inputTensorOperands.size() == 1 &&
         loopNest.inputMaps.front().isIdentity()) {
       auto spType =
           spAnalysis.getSparsityType(loopNest.inputTensorOperands.front());
-      if (spType.hasValue() && spType.getValue() == HotSparsityType::OneHot) {
+      if (spType.has_value() && spType.value() == HotSparsityType::OneHot) {
         Location loc = op.getLoc();
-        BlockAndValueMapping map;
+        IRMapping map;
         Value sparseIndices =
             spAnalysis.getIndices(loopNest.inputTensorOperands.front())
-                .getValue();
+                .value();
         map.map(loopNest.inductionVars,
                 convertIndicesToValues(loc, sparseIndices, rewriter));
         map.map(loopNest.inputRegionArgs, loopNest.inputTensorOperands);
@@ -634,7 +641,7 @@ public:
           for (OpResult result : newOp->getResults()) {
             if (auto rankedTensorType =
                     result.getType().dyn_cast<RankedTensorType>()) {
-              if (spAnalysis.getSparsityEncoding(rankedTensorType).hasValue()) {
+              if (spAnalysis.getSparsityEncoding(rankedTensorType).has_value()) {
                 result.setType(stripEncoding(rankedTensorType));
               }
             }
@@ -661,7 +668,7 @@ public:
           OpResult originalResult = std::get<1>(tup);
           auto newIndices = rewriter.create<memref::AllocaOp>(
               op.getLoc(), sparseIndices.getType().cast<MemRefType>());
-          for (auto pair : llvm::enumerate(insertOp.indices())) {
+          for (auto pair : llvm::enumerate(insertOp.getIndices())) {
             Value spIdx =
                 rewriter.create<arith::ConstantIndexOp>(loc, pair.index());
             rewriter.create<memref::StoreOp>(loc, pair.value(), newIndices,
@@ -674,7 +681,7 @@ public:
       }
     }
 
-    rewriter.updateRootInPlace(op, [&]() {
+    rewriter.modifyOpInPlace(op, [&]() {
       stripEncodingFromLoop(op);
       op.walk([&](scf::ForOp childLoop) { stripEncodingFromLoop(childLoop); });
     });
@@ -685,11 +692,11 @@ public:
 
 bool matchSparsifyInsertSlice(tensor::InsertSliceOp op,
                               SparsePropagation &spAnalysis) {
-  Optional<HotSparsityType> spType = spAnalysis.getSparsityType(op.result());
-  Optional<HotSparsityType> destSpType = spAnalysis.getSparsityType(op.dest());
-  Optional<Value> indices = spAnalysis.getIndices(op.source());
-  return spType.hasValue() && destSpType.hasValue() && indices.hasValue() &&
-         destSpType.getValue() == HotSparsityType::Empty;
+  std::optional<HotSparsityType> spType = spAnalysis.getSparsityType(op.getResult());
+  std::optional<HotSparsityType> destSpType = spAnalysis.getSparsityType(op.getDest());
+  std::optional<Value> indices = spAnalysis.getIndices(op.getSource());
+  return spType.has_value() && destSpType.has_value() && indices.has_value() &&
+         destSpType.value() == HotSparsityType::Empty;
 }
 
 class SparsifyInsertSlice : public OpConversionPattern<tensor::InsertSliceOp> {
@@ -698,16 +705,16 @@ private:
   bool isRowInsertion(tensor::InsertSliceOp op) const {
     auto inferredType =
         tensor::ExtractSliceOp::inferResultType(
-            op.getType(), extractFromI64ArrayAttr(op.static_offsets()),
-            extractFromI64ArrayAttr(op.static_sizes()),
-            extractFromI64ArrayAttr(op.static_strides()))
+            op.getSource().getType().cast<RankedTensorType>(), op.getStaticOffsets(),
+            op.getStaticSizes(),
+            op.getStaticStrides())
             .cast<RankedTensorType>();
-    Optional<llvm::SmallDenseSet<unsigned>> mask = computeRankReductionMask(
+    std::optional<llvm::SmallDenseSet<unsigned>> mask = computeRankReductionMask(
         inferredType.getShape(), op.getSourceType().getShape());
-    if (!mask.hasValue()) {
+    if (!mask.has_value()) {
       return false;
     }
-    return !mask.getValue().contains(inferredType.getRank() - 1);
+    return !mask.value().contains(inferredType.getRank() - 1);
   }
 
 public:
@@ -715,14 +722,14 @@ public:
       : OpConversionPattern(ctx, /*benefit=*/1), spAnalysis{spAnalysis} {}
 
   LogicalResult
-  matchAndRewrite(tensor::InsertSliceOp op, ArrayRef<Value> operands,
+  matchAndRewrite(tensor::InsertSliceOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     if (!matchSparsifyInsertSlice(op, spAnalysis)) {
       return failure();
     }
-    Optional<HotSparsityType> spType = spAnalysis.getSparsityType(op.result());
-    Optional<Value> indices = spAnalysis.getIndices(op.source());
-    if (!indices.hasValue()) {
+    std::optional<HotSparsityType> spType = spAnalysis.getSparsityType(op.getResult());
+    std::optional<Value> indices = spAnalysis.getIndices(op.getSource());
+    if (!indices.has_value()) {
       op.emitError() << "sparse op was missing indices\n";
       return failure();
     }
@@ -731,9 +738,9 @@ public:
     auto intToAttr = [&](int64_t i) {
       return IntegerAttr::get(IntegerType::get(rewriter.getContext(), 64), i);
     };
-    switch (spType.getValue()) {
+    switch (spType.value()) {
     case HotSparsityType::OneHot: {
-      if (indices.getValue().getType().isa<IndexType>()) {
+      if (indices.value().getType().isa<IndexType>()) {
         assert(isRowInsertion(op) && "only row 1-d insertions supported");
         SmallVector<Value> valueOffsets;
 
@@ -743,30 +750,28 @@ public:
             valueOffsets.push_back(offset.get<Value>());
           } else {
             valueOffsets.push_back(rewriter.create<arith::ConstantIndexOp>(
-                loc, offset.get<Attribute>()
-                         .cast<IntegerAttr>()
-                         .getValue()
-                         .getSExtValue()));
+                 loc, offset.get<Attribute>()
+                           .cast<IntegerAttr>()
+                           .getValue()
+                           .getSExtValue()));
           }
         }
 
-        APInt lastOffset = op.static_offsets()[op.static_offsets().size() - 1]
-                               .cast<IntegerAttr>()
-                               .getValue();
-        if (lastOffset.isZero()) {
-          valueOffsets.push_back(indices.getValue());
+        int64_t lastOffset = op.getStaticOffsets()[op.getStaticOffsets().size() - 1];
+        if (lastOffset == 0) {
+          valueOffsets.push_back(indices.value());
         } else {
           valueOffsets.push_back(rewriter.create<arith::AddIOp>(
               loc,
               rewriter.create<arith::ConstantIndexOp>(
-                  loc, lastOffset.getSExtValue()),
-              indices.getValue()));
+                  loc, lastOffset),
+              indices.value()));
           // TODO: propagate indices properly
           // spAnalysis
         }
-        Value scalar = rewriter.create<tensor::ExtractOp>(loc, op.source(),
-                                                          indices.getValue());
-        rewriter.replaceOpWithNewOp<tensor::InsertOp>(op, scalar, op.dest(),
+        Value scalar = rewriter.create<tensor::ExtractOp>(loc, op.getSource(),
+                                                          indices.value());
+        rewriter.replaceOpWithNewOp<tensor::InsertOp>(op, scalar, op.getDest(),
                                                       valueOffsets);
       }
       break;
@@ -774,30 +779,30 @@ public:
     case HotSparsityType::RowHot: {
       SmallVector<OpFoldResult> offsets;
       SmallVector<OpFoldResult> sizes{op.getMixedSizes()};
-      offsets.append({indices.getValue(), intToAttr(0)});
+      offsets.append({indices.value(), intToAttr(0)});
       sizes[0] = intToAttr(1);
 
       auto slice = rewriter.create<tensor::ExtractSliceOp>(
-          loc, op.source(), offsets, sizes, op.getMixedStrides());
+          loc, op.getSource(), offsets, sizes, op.getMixedStrides());
       assert(op.getMixedOffsets()[0]
-                 .get<Attribute>()
-                 .cast<IntegerAttr>()
-                 .getValue()
-                 .isZero() &&
+                  .get<Attribute>()
+                  .cast<IntegerAttr>()
+                  .getValue()
+                  .isZero() &&
              "nonzero row offset for row-hot insert not yet supported");
       rewriter.replaceOpWithNewOp<tensor::InsertSliceOp>(
-          op, slice, op.dest(), offsets, sizes, op.getMixedStrides());
+          op, slice, op.getDest(), offsets, sizes, op.getMixedStrides());
       break;
     }
     default:
       errs() << op.getLoc() << "\n";
-      errs() << "sparsify tensor.insert_slice for " << spType.getValue()
+      errs() << "sparsify tensor.insert_slice for " << spType.value()
              << " not yet implemented\n";
       llvm_unreachable("Not yet implemented");
     }
 
     // propagate indices
-    spAnalysis.setIndices(op.result(), indices.getValue());
+    spAnalysis.setIndices(op.getResult(), indices.value());
     return success();
   }
 };
@@ -838,17 +843,17 @@ struct StructuredSparsifyPass : public OperationPass<ModuleOp> {
 
     TypeConverter typeConverter;
     ConversionTarget target(*context);
-    target.addLegalDialect<arith::ArithmeticDialect>();
+    target.addLegalDialect<arith::ArithDialect>();
     target.addLegalDialect<memref::MemRefDialect>();
     target.addLegalDialect<scf::SCFDialect>();
     target.addDynamicallyLegalOp<scf::ForOp>([&](scf::ForOp op) {
       return !matchSparsifyForOp(op, sparsePropagation, loopNestAnalysis);
     });
-    target.addDynamicallyLegalOp<FuncOp>([&](FuncOp funcOp) {
+    target.addDynamicallyLegalOp<func::FuncOp>([&](func::FuncOp funcOp) {
       return llvm::none_of(funcOp.getArguments(), [&sparsePropagation](
                                                       BlockArgument arg) {
-        bool hasIndex = sparsePropagation.getIndices(arg).hasValue();
-        return sparsePropagation.getSparsityType(arg).hasValue() && !hasIndex;
+        bool hasIndex = sparsePropagation.getIndices(arg).has_value();
+        return sparsePropagation.getSparsityType(arg).has_value() && !hasIndex;
       });
     });
     target.addLegalOp<tensor::ExtractOp, tensor::InsertOp,

--- a/lib/LAGrad/StaticAllocs.cpp
+++ b/lib/LAGrad/StaticAllocs.cpp
@@ -4,10 +4,10 @@
  */
 #include "LAGrad/Passes.h"
 #include "LAGrad/Utils.h"
-#include "mlir/Dialect/Arithmetic/IR/Arithmetic.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
-#include "mlir/Dialect/StandardOps/IR/Ops.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Transforms/DialectConversion.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "mlir/Transforms/Passes.h"
@@ -36,18 +36,15 @@ public:
       return failure();
     }
 
-    auto elementType = ptrToIntOp.arg()
-                           .getType()
-                           .dyn_cast<LLVM::LLVMPointerType>()
-                           .getElementType();
+    auto elementType = gepOp.getElemType();
 
     size_t allocSize = elementType.getIntOrFloatBitWidth() / 8;
-    for (auto indexVal : gepOp.indices()) {
+    for (auto indexVal : gepOp.getIndices()) {
       auto indexConstOp =
-          dyn_cast_or_null<LLVM::ConstantOp>(indexVal.getDefiningOp());
+          dyn_cast_or_null<LLVM::ConstantOp>(indexVal.get<mlir::Value>().getDefiningOp());
       assert(indexConstOp &&
              "Expected index value to be defined by a constant op");
-      allocSize *= indexConstOp.value()
+      allocSize *= indexConstOp.getValue()
                        .dyn_cast<IntegerAttr>()
                        .getValue()
                        .getSExtValue();
@@ -55,7 +52,7 @@ public:
 
     auto staticSize = rewriter.create<LLVM::ConstantOp>(
         op->getLoc(), rewriter.getI64Type(), rewriter.getIndexAttr(allocSize));
-    rewriter.updateRootInPlace(op, [&]() { op.setOperand(staticSize); });
+    rewriter.modifyOpInPlace(op, [&]() { op.setOperand(staticSize); });
     return success();
   }
 };
@@ -68,7 +65,7 @@ public:
   LogicalResult matchAndRewrite(Operation *op,
                                 PatternRewriter &rewriter) const override {
     auto callOp = dyn_cast_or_null<LLVM::CallOp>(op);
-    if (!callOp || callOp.calleeAttr().getValue() != "malloc") {
+    if (!callOp || callOp.getCalleeAttr().getValue() != "malloc") {
       return failure();
     }
 
@@ -87,25 +84,22 @@ public:
       return failure();
     }
 
-    auto elementType = ptrToIntOp.arg()
-                           .getType()
-                           .dyn_cast<LLVM::LLVMPointerType>()
-                           .getElementType();
+    auto elementType = gepOp.getElemType();
 
     size_t allocSize = elementType.getIntOrFloatBitWidth() / 8;
-    if (!llvm::all_of(gepOp.indices(), [](Value indexVal) {
-          return isa<LLVM::ConstantOp>(indexVal.getDefiningOp());
+    if (!llvm::all_of(gepOp.getIndices(), [](auto indexVal) {
+          return isa<LLVM::ConstantOp>(indexVal.template get<mlir::Value>().getDefiningOp());
         })) {
       // Enzyme appears to handle dynamic shapes okay.
       return failure();
     }
 
-    for (auto indexVal : gepOp.indices()) {
+    for (auto indexVal : gepOp.getIndices()) {
       auto indexConstOp =
-          dyn_cast_or_null<LLVM::ConstantOp>(indexVal.getDefiningOp());
+          dyn_cast_or_null<LLVM::ConstantOp>(indexVal.get<mlir::Value>().getDefiningOp());
       assert(indexConstOp &&
              "Expected index value to be defined by a constant op");
-      allocSize *= indexConstOp.value()
+      allocSize *= indexConstOp.getValue()
                        .dyn_cast<IntegerAttr>()
                        .getValue()
                        .getSExtValue();
@@ -113,8 +107,8 @@ public:
 
     auto staticSize = rewriter.create<LLVM::ConstantOp>(
         op->getLoc(), rewriter.getI64Type(), rewriter.getIndexAttr(allocSize));
-    rewriter.updateRootInPlace(callOp,
-                               [&]() { callOp.setOperand(0, staticSize); });
+    rewriter.modifyOpInPlace(callOp,
+                             [&]() { callOp.setOperand(0, staticSize); });
     return success();
   }
 };
@@ -137,7 +131,7 @@ struct StaticAllocsPass
     patterns.add<ConvertStaticMalloc>(patterns.getContext());
     patterns.add<ConvertStaticAlloca>(patterns.getContext());
 
-    if (failed(applyPatternsAndFoldGreedily(getOperation()->getRegions(),
+    if (failed(applyPatternsAndFoldGreedily(getOperation(),
                                             std::move(patterns)))) {
       signalPassFailure();
     }

--- a/lib/LAGrad/TriangularLoops.cpp
+++ b/lib/LAGrad/TriangularLoops.cpp
@@ -4,12 +4,14 @@
  */
 #include "LAGrad/Passes.h"
 #include "LAGrad/Utils.h"
-#include "mlir/Dialect/Arithmetic/IR/Arithmetic.h"
-#include "mlir/Dialect/Linalg/IR/LinalgOps.h"
+#include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Bufferization/IR/Bufferization.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/Linalg/Utils/Utils.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
-#include "mlir/Dialect/SCF/SCF.h"
-#include "mlir/Dialect/StandardOps/IR/Ops.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/Dialect/Tensor/Transforms/Passes.h"
 #include "mlir/Transforms/DialectConversion.h"
@@ -70,7 +72,7 @@ void eraseTriangularEncoding(Value operand, PatternRewriter &rewriter) {
       auto definingOp = operand.getDefiningOp();
       if (definingOp && dyn_cast_or_null<arith::ConstantOp>(definingOp)) {
         auto constOp = dyn_cast<arith::ConstantOp>(definingOp);
-        auto attr = constOp.valueAttr();
+        auto attr = constOp.getValueAttr();
         if (attr.isa<DenseElementsAttr>()) {
           auto dattr = attr.cast<DenseElementsAttr>();
           assert(dattr.isSplat() && "triangular loops for non-splatted dense "
@@ -79,7 +81,7 @@ void eraseTriangularEncoding(Value operand, PatternRewriter &rewriter) {
             rewriter.setInsertionPoint(constOp);
             rewriter.replaceOpWithNewOp<arith::ConstantOp>(
                 constOp, DenseElementsAttr::get(resultTensorType,
-                                                dattr.getSplatValue()));
+                                                dattr.getSplatValue<IntegerAttr>()));
           }
         }
         return;
@@ -90,8 +92,8 @@ void eraseTriangularEncoding(Value operand, PatternRewriter &rewriter) {
       // }
 
       auto parent = operand.getParentRegion()->getParentOp();
-      if (parent && dyn_cast_or_null<FuncOp>(parent)) {
-        auto funcOp = dyn_cast<FuncOp>(parent);
+      if (parent && dyn_cast_or_null<func::FuncOp>(parent)) {
+        auto funcOp = dyn_cast<func::FuncOp>(parent);
         SmallVector<Type> argumentTypes;
         int index = 0;
         for (auto arg : funcOp.getArguments()) {
@@ -103,11 +105,11 @@ void eraseTriangularEncoding(Value operand, PatternRewriter &rewriter) {
           index++;
         }
         // funcOp.setType(FunctionType::get(funcOp.getContext(), argumentTypes,
-        //                                  funcOp.getType().getResults()));
-        funcOp.setType(stripEncodingFromFunc(funcOp.getType()));
+        //                                  funcOp.getFunctionType().getResults()));
+        funcOp.setType(stripEncodingFromFunc(funcOp.getFunctionType()));
         auto uses = funcOp.getSymbolUses(funcOp->getParentOfType<ModuleOp>());
-        if (uses.hasValue()) {
-          for (auto use : uses.getValue()) {
+        if (uses.has_value()) {
+          for (auto use : uses.value()) {
             for (auto useOperand : use.getUser()->getOperands()) {
               eraseTriangularEncoding(useOperand, rewriter);
             }
@@ -128,9 +130,12 @@ static void unpackRanges(ArrayRef<Range> ranges, SmallVectorImpl<Value> &lbs,
                          SmallVectorImpl<Value> &ubs,
                          SmallVectorImpl<Value> &steps) {
   for (Range range : ranges) {
-    lbs.emplace_back(range.offset);
-    ubs.emplace_back(range.size);
-    steps.emplace_back(range.stride);
+    if (auto offsetVal = range.offset.dyn_cast<Value>())
+      lbs.push_back(offsetVal);
+    if (auto sizeVal = range.size.dyn_cast<Value>())
+      ubs.push_back(sizeVal);
+    if (auto strideVal = range.stride.dyn_cast<Value>())
+      steps.push_back(strideVal);
   }
 }
 
@@ -147,8 +152,8 @@ static SmallVector<Value> makeCanonicalAffineApplies(OpBuilder &b, Location loc,
   for (auto e : map.getResults()) {
     auto exprMap = AffineMap::get(dims, map.getNumSymbols(), e);
     SmallVector<Value> operands(vals.begin(), vals.end());
-    canonicalizeMapAndOperands(&exprMap, &operands);
-    res.push_back(b.create<AffineApplyOp>(loc, exprMap, operands));
+    affine::canonicalizeMapAndOperands(&exprMap, &operands);
+    res.push_back(b.create<affine::AffineApplyOp>(loc, exprMap, operands));
   }
   return res;
 }
@@ -160,7 +165,7 @@ inlineRegionAndEmitStore(OpBuilder &b, Location loc, linalg::LinalgOp op,
                          ArrayRef<SmallVector<Value>> indexing,
                          ArrayRef<Value> outputTensors) {
   auto &block = op->getRegion(0).front();
-  BlockAndValueMapping map;
+  IRMapping map;
   map.map(block.getArguments(), indexedValues);
   for (auto &op : block.without_terminator()) {
     auto *newOp = b.clone(op, map);
@@ -182,33 +187,33 @@ static SmallVector<Value> emitScalarImplementation(OpBuilder &b, Location loc,
                                                    ValueRange allIvs,
                                                    ValueRange iterArgs,
                                                    linalg::LinalgOp linalgOp) {
-  assert(iterArgs.size() == linalgOp.getOutputTensorOperands().size() &&
+  assert(iterArgs.size() == linalgOp.getDpsInits().size() &&
          "Expected # of iter args to be equal to # of output tensor operands.");
 
   SmallVector<Value> indexedValues;
-  indexedValues.reserve(linalgOp.getNumInputsAndOutputs());
+  indexedValues.reserve(linalgOp.getNumDpsInputs() + linalgOp.getNumDpsInits());
 
   auto allIvsPlusDims = SmallVector<Value>(allIvs.begin(), allIvs.end());
   // 1.a. Emit load from input operands or for scalars access the operand
   // itself.
-  for (auto inputOperand : linalgOp.getInputOperands()) {
+  for (auto inputOperand : linalgOp.getDpsInputOperands()) {
     if (linalgOp.isScalar(inputOperand)) {
       indexedValues.push_back(inputOperand->get());
       continue;
     }
     auto indexing = makeCanonicalAffineApplies(
-        b, loc, linalgOp.getTiedIndexingMap(inputOperand), allIvsPlusDims);
+        b, loc, cast<AffineMapAttr>(linalgOp.getIndexingMaps()[inputOperand->getOperandNumber()]).getValue(), allIvsPlusDims);
     indexedValues.push_back(
         b.create<tensor::ExtractOp>(loc, inputOperand->get(), indexing));
   }
 
   // 1.b. Emit load from output views.
-  for (auto pair : llvm::zip(linalgOp.getOutputOperands(), iterArgs)) {
-    auto outputOperand = std::get<0>(pair);
-    Value iterArg = std::get<1>(pair);
+  for (int64_t i = 0, e = linalgOp.getNumDpsInits(); i < e; ++i) {
+    auto outputOperand = linalgOp.getDpsInitOperand(i);
+    Value iterArg = iterArgs[i];
 
     auto indexing = makeCanonicalAffineApplies(
-        b, loc, linalgOp.getTiedIndexingMap(outputOperand), allIvsPlusDims);
+        b, loc, cast<AffineMapAttr>(linalgOp.getIndexingMaps()[outputOperand->getOperandNumber()]).getValue(), allIvsPlusDims);
     indexedValues.push_back(
         b.create<tensor::ExtractOp>(loc, iterArg, indexing));
   }
@@ -217,9 +222,10 @@ static SmallVector<Value> emitScalarImplementation(OpBuilder &b, Location loc,
   // 3. Emit store.
   SmallVector<Value> outputTensors{iterArgs};
   SmallVector<SmallVector<Value>, 8> indexing;
-  for (auto outputOperand : linalgOp.getOutputTensorOperands()) {
+  for (int64_t i = 0, e = linalgOp.getNumDpsInits(); i < e; ++i) {
+    auto outputOperand = linalgOp.getDpsInitOperand(i);
     indexing.push_back(makeCanonicalAffineApplies(
-        b, loc, linalgOp.getTiedIndexingMap(outputOperand), allIvsPlusDims));
+        b, loc, cast<AffineMapAttr>(linalgOp.getIndexingMaps()[outputOperand->getOperandNumber()]).getValue(), allIvsPlusDims));
   }
   return inlineRegionAndEmitStore(b, loc, linalgOp, indexedValues, indexing,
                                   outputTensors);
@@ -233,7 +239,7 @@ public:
   LogicalResult matchAndRewrite(Operation *op,
                                 PatternRewriter &rewriter) const override {
     auto linalgOp = dyn_cast_or_null<linalg::LinalgOp>(op);
-    if (!linalgOp || !linalgOp.hasTensorSemantics()) {
+    if (!linalgOp || !linalgOp.hasPureTensorSemantics()) {
       return failure();
     }
     auto genericOp =
@@ -261,31 +267,30 @@ public:
     });
 
     auto loopRanges = linalgOp.createLoopRanges(rewriter, linalgOp.getLoc());
-    auto iteratorTypes =
-        llvm::to_vector<4>(linalgOp.iterator_types().getValue());
+    auto iteratorTypes = linalgOp.getIteratorTypesArray();
     SmallVector<Value, 4> lbs, ubs, steps;
     unpackRanges(loopRanges, lbs, ubs, steps);
-    assert(linalgOp.getOutputTensorOperands().size() > 0 &&
+    assert(linalgOp.getDpsInits().size() > 0 &&
            "Expected at least one tensor result");
     SmallVector<Value> iterArgInitValues;
+    auto initType = linalgOp.getDpsInits().getTypes()[0].cast<ShapedType>();
     Value zero = rewriter.create<arith::ConstantOp>(
         linalgOp.getLoc(),
-        FloatAttr::get(linalgOp.getOutputTensorTypes()[0].getElementType(),
-                       0.0));
-    for (auto outputTensor : linalgOp.getOutputTensorOperands()) {
-      auto outType =
-          outputTensor->get().getType().dyn_cast_or_null<ShapedType>();
+        FloatAttr::get(initType.getElementType(), 0.0));
+    for (int64_t i = 0, e = linalgOp.getNumDpsInits(); i < e; ++i) {
+      Value outputTensor = linalgOp.getDpsInits()[i];
+      auto outType = outputTensor.getType().dyn_cast_or_null<ShapedType>();
       assert(outType && "outType was null");
       // Perhaps a premature optimization. Using an init tensor op results in an
       // extra buffer allocation.
       auto space = rewriter.create<memref::AllocOp>(
           linalgOp.getLoc(),
           MemRefType::get(outType.getShape(), outType.getElementType()));
-      if (linalgOp.payloadUsesValueFromOperand(outputTensor)) {
-        rewriter.create<linalg::FillOp>(linalgOp.getLoc(), zero, space);
+      if (linalgOp.payloadUsesValueFromOperand(linalgOp.getDpsInitOperand(i))) {
+        rewriter.create<linalg::FillOp>(linalgOp.getLoc(), ValueRange{zero}, ValueRange{space.getResult()});
       }
       auto loaded =
-          rewriter.create<memref::TensorLoadOp>(linalgOp.getLoc(), space);
+          rewriter.create<bufferization::ToTensorOp>(linalgOp.getLoc(), space);
 
       iterArgInitValues.push_back(loaded);
     }
@@ -306,7 +311,7 @@ public:
     auto last = loopNest.loops[num_loops - 1];
     last.setUpperBound(loopNest.loops[num_loops - 2].getInductionVar());
 
-    op->replaceAllUsesWith(loopNest.getResults());
+    op->replaceAllUsesWith(loopNest.results);
     rewriter.eraseOp(op);
 
     return success();
@@ -331,11 +336,11 @@ struct TriangularLoopsPass
     auto *context = &getContext();
     ConversionTarget target(*context);
     RewritePatternSet patterns(context);
-    target.addLegalDialect<arith::ArithmeticDialect>();
+    target.addLegalDialect<arith::ArithDialect>();
     target.addLegalDialect<memref::MemRefDialect>();
     target.addLegalDialect<scf::SCFDialect>();
     target.addLegalDialect<tensor::TensorDialect>();
-    target.addLegalOp<linalg::InitTensorOp>();
+    target.addLegalOp<tensor::EmptyOp>();
     target.addLegalOp<linalg::FillOp>();
     target.addLegalOp<linalg::YieldOp>();
 

--- a/lib/LAGrad/TriangularPacking.cpp
+++ b/lib/LAGrad/TriangularPacking.cpp
@@ -2,12 +2,15 @@
 #include "LAGrad/Logger.h"
 #include "LAGrad/Passes.h"
 #include "LAGrad/Utils.h"
-#include "mlir/Dialect/Arithmetic/IR/Arithmetic.h"
-#include "mlir/Dialect/Linalg/IR/LinalgOps.h"
+#include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Bufferization/IR/Bufferization.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/Linalg/Utils/Utils.h"
+#include "mlir/Dialect/Math/IR/Math.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
-#include "mlir/Dialect/SCF/SCF.h"
-#include "mlir/Dialect/StandardOps/IR/Ops.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/Dialect/Tensor/Transforms/Passes.h"
 #include "mlir/Transforms/DialectConversion.h"
@@ -32,10 +35,10 @@ bool hasPackedEncoding(Type type) {
 }
 
 bool hasPackedEncoding(linalg::LinalgOp op) {
-  if (!op.hasTensorSemantics()) {
+  if (!op.hasPureTensorSemantics()) {
     return false;
   }
-  for (OpOperand *operand : op.getInputAndOutputOperands()) {
+  for (OpOperand *operand : op.getDpsInputOperands()) {
     if (hasPackedEncoding(operand->get().getType())) {
       return true;
     }
@@ -65,9 +68,12 @@ static void unpackRanges(ArrayRef<Range> ranges, SmallVectorImpl<Value> &lbs,
                          SmallVectorImpl<Value> &ubs,
                          SmallVectorImpl<Value> &steps) {
   for (Range range : ranges) {
-    lbs.emplace_back(range.offset);
-    ubs.emplace_back(range.size);
-    steps.emplace_back(range.stride);
+    if (auto offsetVal = range.offset.dyn_cast<Value>())
+      lbs.push_back(offsetVal);
+    if (auto sizeVal = range.size.dyn_cast<Value>())
+      ubs.push_back(sizeVal);
+    if (auto strideVal = range.stride.dyn_cast<Value>())
+      steps.push_back(strideVal);
   }
 }
 
@@ -86,12 +92,12 @@ static SmallVector<Value> makeCanonicalAffineApplies(OpBuilder &b, Location loc,
   for (auto e : map.getResults()) {
     if (hasPackedEncoding(operandType)) {
       auto exprMap = AffineMap::get(dims, map.getNumSymbols(), e);
-      res.push_back(b.create<AffineApplyOp>(loc, exprMap, trilIndices));
+      res.push_back(b.create<affine::AffineApplyOp>(loc, exprMap, trilIndices));
     } else {
       auto exprMap = AffineMap::get(dims, map.getNumSymbols(), e);
       SmallVector<Value> operands(vals.begin(), vals.end());
-      canonicalizeMapAndOperands(&exprMap, &operands);
-      res.push_back(b.create<AffineApplyOp>(loc, exprMap, operands));
+      affine::canonicalizeMapAndOperands(&exprMap, &operands);
+      res.push_back(b.create<affine::AffineApplyOp>(loc, exprMap, operands));
     }
   }
   return res;
@@ -104,7 +110,7 @@ inlineRegionAndEmitStore(OpBuilder &b, Location loc, linalg::LinalgOp op,
                          ArrayRef<SmallVector<Value>> indexing,
                          ArrayRef<Value> outputTensors) {
   auto &block = op->getRegion(0).front();
-  BlockAndValueMapping map;
+  IRMapping map;
   map.map(block.getArguments(), indexedValues);
   for (auto &op : block.without_terminator()) {
     auto *newOp = b.clone(op, map);
@@ -149,11 +155,11 @@ static SmallVector<Value> emitScalarImplementation(OpBuilder &b, Location loc,
                                                    ValueRange iterArgs,
                                                    linalg::LinalgOp linalgOp,
                                                    Value triDim) {
-  assert(iterArgs.size() == linalgOp.getOutputTensorOperands().size() &&
+  assert(iterArgs.size() == linalgOp.getDpsInits().size() &&
          "Expected # of iter args to be equal to # of output tensor operands.");
 
   SmallVector<Value> indexedValues;
-  indexedValues.reserve(linalgOp.getNumInputsAndOutputs());
+  indexedValues.reserve(linalgOp.getNumDpsInputs() + linalgOp.getNumDpsInits());
 
   auto allIvsPlusDims = SmallVector<Value>(allIvs.begin(), allIvs.end());
 
@@ -172,25 +178,25 @@ static SmallVector<Value> emitScalarImplementation(OpBuilder &b, Location loc,
 
   // 1.a. Emit load from input operands or for scalars access the operand
   // itself.
-  for (auto inputOperand : linalgOp.getInputOperands()) {
+  for (auto inputOperand : linalgOp.getDpsInputOperands()) {
     if (linalgOp.isScalar(inputOperand)) {
       indexedValues.push_back(inputOperand->get());
       continue;
     }
     auto indexing = makeCanonicalAffineApplies(
-        b, loc, linalgOp.getTiedIndexingMap(inputOperand), allIvsPlusDims,
+        b, loc, cast<AffineMapAttr>(linalgOp.getIndexingMaps()[inputOperand->getOperandNumber()]).getValue(), allIvsPlusDims,
         inputOperand->get().getType(), trilIndices);
     indexedValues.push_back(
         b.create<tensor::ExtractOp>(loc, inputOperand->get(), indexing));
   }
 
   // 1.b. Emit load from output views.
-  for (auto pair : llvm::zip(linalgOp.getOutputOperands(), iterArgs)) {
-    auto outputOperand = std::get<0>(pair);
-    Value iterArg = std::get<1>(pair);
+  for (int64_t i = 0, e = linalgOp.getNumDpsInits(); i < e; ++i) {
+    auto outputOperand = linalgOp.getDpsInitOperand(i);
+    Value iterArg = iterArgs[i];
 
     auto indexing = makeCanonicalAffineApplies(
-        b, loc, linalgOp.getTiedIndexingMap(outputOperand), allIvsPlusDims,
+        b, loc, cast<AffineMapAttr>(linalgOp.getIndexingMaps()[outputOperand->getOperandNumber()]).getValue(), allIvsPlusDims,
         outputOperand->get().getType(), trilIndices);
     indexedValues.push_back(
         b.create<tensor::ExtractOp>(loc, iterArg, indexing));
@@ -200,9 +206,10 @@ static SmallVector<Value> emitScalarImplementation(OpBuilder &b, Location loc,
   // 3. Emit store.
   SmallVector<Value> outputTensors{iterArgs};
   SmallVector<SmallVector<Value>, 8> indexing;
-  for (auto outputOperand : linalgOp.getOutputTensorOperands()) {
+  for (int64_t i = 0, e = linalgOp.getNumDpsInits(); i < e; ++i) {
+    auto outputOperand = linalgOp.getDpsInitOperand(i);
     indexing.push_back(makeCanonicalAffineApplies(
-        b, loc, linalgOp.getTiedIndexingMap(outputOperand), allIvsPlusDims,
+        b, loc, cast<AffineMapAttr>(linalgOp.getIndexingMaps()[outputOperand->getOperandNumber()]).getValue(), allIvsPlusDims,
         outputOperand->get().getType(), trilIndices));
   }
   return inlineRegionAndEmitStore(b, loc, linalgOp, indexedValues, indexing,
@@ -214,7 +221,7 @@ public:
   using OpInterfaceRewritePattern::OpInterfaceRewritePattern;
   LogicalResult matchAndRewrite(linalg::LinalgOp op,
                                 PatternRewriter &rewriter) const override {
-    if (!op.hasTensorSemantics()) {
+    if (!op.hasPureTensorSemantics()) {
       return failure();
     }
     if (!hasPackedEncoding(op)) {
@@ -222,13 +229,14 @@ public:
     }
 
     auto loopRanges = op.createLoopRanges(rewriter, op.getLoc());
-    auto iteratorTypes = llvm::to_vector<4>(op.iterator_types().getValue());
+    auto iteratorTypes = op.getIteratorTypesArray();
     SmallVector<Value, 4> lbs, ubs, steps;
     unpackRanges(loopRanges, lbs, ubs, steps);
     // Initialize space for outputs
     SmallVector<Value> iterArgsInit;
-    iterArgsInit.reserve(op.getNumOutputs());
-    for (OpOperand *outTensor : op.getOutputTensorOperands()) {
+    iterArgsInit.reserve(op.getNumDpsInits());
+    for (int64_t i = 0, e = op.getNumDpsInits(); i < e; ++i) {
+      OpOperand *outTensor = op.getDpsInitOperand(i);
       // TODO: This is a bandaid, need some way of determining when it's safe to
       // write.
       if (isa_and_nonnull<tensor::ExtractSliceOp>(
@@ -237,23 +245,22 @@ public:
       } else {
         auto outType = outTensor->get().getType().cast<RankedTensorType>();
 
-        auto memrefType =
+        MemRefType memrefType =
             hasPackedEncoding(outType)
-                ? BufferizeTypeConverter().convertType(
-                      convertToPackedType(outType))
+                ? MemRefType::get(outType.getShape(), convertToPackedType(outType).getElementType())
                 : MemRefType::get(outType.getShape(), outType.getElementType());
-        Value space = rewriter.create<linalg::InitTensorOp>(
+        Value space = rewriter.create<tensor::EmptyOp>(
             op.getLoc(), outType.getShape(), outType.getElementType());
         if (hasPackedEncoding(outType)) {
           space = rewriter.create<lagrad::PackOp>(op.getLoc(), outType, space);
         }
         if (op.payloadUsesValueFromOperand(outTensor)) {
-          auto castedSpace = rewriter.create<memref::BufferCastOp>(
+          auto castedSpace = rewriter.create<bufferization::ToMemrefOp>(
               op.getLoc(), memrefType, space);
-          auto memrefOutput = rewriter.create<memref::BufferCastOp>(
+          auto memrefOutput = rewriter.create<bufferization::ToMemrefOp>(
               op.getLoc(), memrefType, outTensor->get());
-          rewriter.create<linalg::CopyOp>(op.getLoc(), memrefOutput,
-                                          castedSpace);
+          rewriter.create<linalg::CopyOp>(op.getLoc(), ValueRange{memrefOutput.getResult()},
+                                          ValueRange{castedSpace.getResult()});
         }
 
         iterArgsInit.push_back(space);
@@ -278,7 +285,7 @@ public:
         rewriter.create<arith::ConstantIndexOp>(op.getLoc(), 1));
     lastLoop.setLowerBound(last_lb);
 
-    rewriter.replaceOp(op, loopNest.getResults());
+    rewriter.replaceOp(op, loopNest.results);
     loopNest.loops.front()->setAttr("Packed loop",
                                     UnitAttr::get(rewriter.getContext()));
     return success();
@@ -303,13 +310,13 @@ private:
   DenseSet<Operation *> cache;
 };
 
-class ErasePackedFuncOp : public OpRewritePattern<FuncOp> {
+class ErasePackedFuncOp : public OpRewritePattern<func::FuncOp> {
 public:
   using OpRewritePattern::OpRewritePattern;
-  LogicalResult matchAndRewrite(FuncOp op,
+  LogicalResult matchAndRewrite(func::FuncOp op,
                                 PatternRewriter &rewriter) const override {
-    op.setType(stripEncodingFromFunc(op.getType()));
-    rewriter.updateRootInPlace(op, [&]() {
+    op.setType(stripEncodingFromFunc(op.getFunctionType()));
+    rewriter.modifyOpInPlace(op, [&]() {
       for (auto arg : op.getArguments()) {
         if (hasPackedEncoding(arg.getType())) {
           arg.setType(
@@ -343,13 +350,13 @@ private:
   }
 };
 
-class ErasePackedCallOp : public OpRewritePattern<CallOp> {
+class ErasePackedCallOp : public OpRewritePattern<func::CallOp> {
   using OpRewritePattern::OpRewritePattern;
-  LogicalResult matchAndRewrite(CallOp op,
+  LogicalResult matchAndRewrite(func::CallOp op,
                                 PatternRewriter &rewriter) const override {
     auto moduleOp = op->getParentOfType<ModuleOp>();
-    auto funcOp = cast<FuncOp>(moduleOp.lookupSymbol(op.calleeAttr()));
-    rewriter.replaceOpWithNewOp<CallOp>(op, funcOp, op.operands());
+    auto funcOp = cast<func::FuncOp>(moduleOp.lookupSymbol(op.getCalleeAttr()));
+    rewriter.replaceOpWithNewOp<func::CallOp>(op, funcOp, op.getOperands());
     return success();
   }
 };
@@ -370,8 +377,8 @@ public:
       return failure();
     }
 
-    rewriter.replaceOpWithNewOp<tensor::ExtractOp>(op, op.tensor(),
-                                                   op.indices().drop_back(1));
+    rewriter.replaceOpWithNewOp<tensor::ExtractOp>(op, op.getTensor(),
+                                                   op.getIndices().drop_back(1));
     return success();
   }
 };
@@ -392,20 +399,20 @@ public:
     }
 
     if (op->hasAttrOfType<UnitAttr>("packed_write")) {
-      rewriter.replaceOpWithNewOp<tensor::InsertOp>(op, op.scalar(),
-      op.dest(),
-                                                    op.indices().drop_back(1));
+      rewriter.replaceOpWithNewOp<tensor::InsertOp>(op, op.getScalar(),
+      op.getDest(),
+                                                    op.getIndices().drop_back(1));
       return success();
     }
-    SmallVector<Value> indices{op.indices().drop_back(2)};
-    auto lastIndices = op.indices().take_back(2);
+    SmallVector<Value> indices{op.getIndices().drop_back(2)};
+    auto lastIndices = op.getIndices().take_back(2);
     int64_t triDim = op.getType().getShape().back();
     // Indices are flipped because the underlying storage is column-major
     Value Lidx = computeLidx(
         rewriter, op.getLoc(), lastIndices[1], lastIndices[0],
         rewriter.create<arith::ConstantIndexOp>(op.getLoc(), triDim));
     indices.push_back(Lidx);
-    rewriter.replaceOpWithNewOp<tensor::InsertOp>(op, op.scalar(), op.dest(),
+    rewriter.replaceOpWithNewOp<tensor::InsertOp>(op, op.getScalar(), op.getDest(),
                                                   indices);
     return success();
   }
@@ -444,7 +451,7 @@ public:
         IntegerAttr::get(IndexType::get(rewriter.getContext()), triSize);
 
     rewriter.replaceOpWithNewOp<tensor::ExtractSliceOp>(
-        op, convertToPackedType(op.getType()), op.source(), offsets, sizes,
+        op, convertToPackedType(op.getType()), op.getSource(), offsets, sizes,
         strides);
     return success();
   }
@@ -483,7 +490,7 @@ public:
         IntegerAttr::get(IndexType::get(rewriter.getContext()), triSize);
 
     rewriter.replaceOpWithNewOp<tensor::InsertSliceOp>(
-        op, op.source(), op.dest(), offsets, sizes, strides);
+        op, op.getSource(), op.getDest(), offsets, sizes, strides);
     return success();
   }
 };
@@ -501,7 +508,7 @@ public:
     if (!packedTensorUsage.usesPackedTensor(op)) {
       return failure();
     }
-    rewriter.replaceOpWithNewOp<tensor::CastOp>(op, op.getType(), op.source());
+    rewriter.replaceOpWithNewOp<tensor::CastOp>(op, op.getType(), op.getSource());
     return success();
   }
 };
@@ -514,17 +521,17 @@ public:
     if (!hasPackedEncoding(op.getType())) {
       return failure();
     }
-    auto sourceType = op.source().getType().dyn_cast<RankedTensorType>();
+    auto sourceType = op.getSource().getType().dyn_cast<RankedTensorType>();
     auto destType = op.getType().dyn_cast<RankedTensorType>();
     // Meant to handle a specific case where an explicit pack op is used because
     // linalg.init_tensor can't make tensors with special encodings.
     if (!(sourceType && destType &&
           sourceType.getShape() == destType.getShape() &&
           sourceType.getElementType() == destType.getElementType() &&
-          isa_and_nonnull<linalg::InitTensorOp>(op.source().getDefiningOp()))) {
+          isa_and_nonnull<tensor::EmptyOp>(op.getSource().getDefiningOp()))) {
       return failure();
     }
-    rewriter.replaceOpWithNewOp<linalg::InitTensorOp>(
+    rewriter.replaceOpWithNewOp<tensor::EmptyOp>(
         op, convertToPackedType(destType).getShape(),
         destType.getElementType());
     return success();
@@ -548,14 +555,14 @@ public:
     }
 
     if (auto constOp = dyn_cast<arith::ConstantOp>(op)) {
-      if (auto valueAttr = constOp.valueAttr().dyn_cast<SplatElementsAttr>()) {
+      if (auto valueAttr = constOp.getValueAttr().dyn_cast<SplatElementsAttr>()) {
         rewriter.replaceOpWithNewOp<arith::ConstantOp>(
             constOp,
             DenseElementsAttr::get(
                 convertToPackedType(constOp.getType().cast<RankedTensorType>()),
-                valueAttr.getSplatValue()));
+                valueAttr.getSplatValue<Attribute>()));
       } else {
-        auto denseAttr = constOp.valueAttr().cast<DenseFPElementsAttr>();
+        auto denseAttr = constOp.getValueAttr().cast<DenseFPElementsAttr>();
         auto tensorType = denseAttr.getType().cast<RankedTensorType>();
         int64_t d = tensorType.getShape().back();
         SmallVector<APFloat> packedValues;
@@ -569,8 +576,9 @@ public:
           for (int64_t m = 0; m < dim; m++) {
             for (int64_t i = 0; i < d; i++) {
               for (int64_t j = i + 1; j < d; j++) {
+                int64_t idx = m * stride + j * d + i;
                 packedValues.push_back(
-                    denseAttr.getFlatValue<APFloat>(m * stride + j * d + i));
+                    denseAttr.getValues<APFloat>()[idx]);
               }
             }
           }
@@ -581,7 +589,7 @@ public:
         rewriter.replaceOpWithNewOp<arith::ConstantOp>(constOp, packedAttr);
       }
     } else {
-      rewriter.updateRootInPlace(op, [&]() {
+      rewriter.modifyOpInPlace(op, [&]() {
         for (auto operand : op->getOperands()) {
           if (hasPackedEncoding(operand.getType())) {
             operand.setType(convertToPackedType(
@@ -609,7 +617,7 @@ public:
                                 PatternRewriter &rewriter) const override {
     // TODO: Could remove this in favour of the more generic EraseEncoding
     // pattern, would need to extend it to traverse region arguments.
-    rewriter.updateRootInPlace(op, [&]() {
+    rewriter.modifyOpInPlace(op, [&]() {
       for (BlockArgument operand : op.getRegionIterArgs()) {
         if (hasPackedEncoding(operand.getType())) {
           operand.setType(
@@ -635,12 +643,12 @@ struct PackTriangularPass
     auto *context = &getContext();
     ConversionTarget target(*context);
     RewritePatternSet patterns(context);
-    target.addLegalDialect<arith::ArithmeticDialect>();
+    target.addLegalDialect<arith::ArithDialect>();
     target.addLegalDialect<math::MathDialect>();
     target.addLegalDialect<memref::MemRefDialect>();
     target.addLegalDialect<scf::SCFDialect>();
     target.addLegalDialect<tensor::TensorDialect>();
-    target.addLegalOp<linalg::InitTensorOp>();
+    target.addLegalOp<tensor::EmptyOp>();
     target.addLegalOp<linalg::FillOp>();
     target.addLegalOp<linalg::CopyOp>();
     target.addLegalOp<linalg::YieldOp>();
@@ -663,8 +671,8 @@ struct PackTriangularPass
     };
     erasureTarget.addDynamicallyLegalDialect<tensor::TensorDialect>(
         packedPredicate);
-    erasureTarget.addDynamicallyLegalOp<CallOp>(packedPredicate);
-    erasureTarget.addDynamicallyLegalDialect<arith::ArithmeticDialect>(
+    erasureTarget.addDynamicallyLegalOp<func::CallOp>(packedPredicate);
+    erasureTarget.addDynamicallyLegalDialect<arith::ArithDialect>(
         [&](Operation *op) {
           auto isPacked = [&](Type type) { return hasPackedEncoding(type); };
           return llvm::none_of(op->getOperandTypes(), isPacked) &&
@@ -682,7 +690,7 @@ struct PackTriangularPass
           return llvm::none_of(op->getOperandTypes(), isPacked) &&
                  llvm::none_of(op->getResultTypes(), isPacked);
         });
-    erasureTarget.addLegalOp<linalg::InitTensorOp>();
+    erasureTarget.addLegalOp<tensor::EmptyOp>();
     erasureTarget.addLegalOp<linalg::CopyOp>();
     // erasureTarget.addLegalOp<linalg::FillOp>();
     // erasureTarget.addLegalOp<linalg::YieldOp>();

--- a/lib/LAGrad/Utils.cpp
+++ b/lib/LAGrad/Utils.cpp
@@ -1,11 +1,15 @@
 #include "LAGrad/Utils.h"
 #include "LAGrad/LAGradOps.h"
-#include "mlir/Analysis/AffineAnalysis.h"
-#include "mlir/Analysis/LoopAnalysis.h"
-#include "mlir/Dialect/Arithmetic/IR/Arithmetic.h"
-#include "mlir/Dialect/Linalg/IR/LinalgOps.h"
-#include "mlir/Dialect/SCF/SCF.h"
-#include "mlir/Dialect/StandardOps/IR/Ops.h"
+#include "mlir/Analysis/SliceAnalysis.h"
+#include "mlir/Dialect/Affine/Analysis/AffineAnalysis.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Bufferization/IR/Bufferization.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/Math/IR/Math.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Transforms/DialectConversion.h"
 #include "llvm/ADT/TypeSwitch.h"
 
@@ -20,7 +24,7 @@ bool isFloatOrFloatTensor(Type typ) {
 
 // Specialization of getSupportedReduction for scf.for ops.
 static Value SCFGetSupportedReduction(scf::ForOp forOp, unsigned pos,
-                                      AtomicRMWKind &kind) {
+                                      arith::AtomicRMWKind &kind) {
   SmallVector<Operation *> combinerOps;
   Value reducedVal =
       matchReduction(forOp.getRegionIterArgs(), pos, combinerOps);
@@ -32,16 +36,16 @@ static Value SCFGetSupportedReduction(scf::ForOp forOp, unsigned pos,
     return nullptr;
 
   Operation *combinerOp = combinerOps.back();
-  Optional<AtomicRMWKind> maybeKind =
-      TypeSwitch<Operation *, Optional<AtomicRMWKind>>(combinerOp)
-          .Case([](arith::AddFOp) { return AtomicRMWKind::addf; })
-          // .Case([](arith::MulFOp) { return AtomicRMWKind::mulf; })
-          .Case([](arith::AddIOp) { return AtomicRMWKind::addi; })
-          // .Case([](arith::MulIOp) { return AtomicRMWKind::muli; })
-          .Default([](Operation *) -> Optional<AtomicRMWKind> {
+  std::optional<arith::AtomicRMWKind> maybeKind =
+      TypeSwitch<Operation *, std::optional<arith::AtomicRMWKind>>(combinerOp)
+          .Case([](arith::AddFOp) { return arith::AtomicRMWKind::addf; })
+          // .Case([](arith::MulFOp) { return arith::AtomicRMWKind::mulf; })
+          .Case([](arith::AddIOp) { return arith::AtomicRMWKind::addi; })
+          // .Case([](arith::MulIOp) { return arith::AtomicRMWKind::muli; })
+          .Default([](Operation *) -> std::optional<arith::AtomicRMWKind> {
             // TODO: AtomicRMW supports other kinds of reductions this is
             // currently not detecting, add those when the need arises.
-            return llvm::None;
+            return std::nullopt;
           });
   if (!maybeKind)
     return nullptr;
@@ -51,22 +55,22 @@ static Value SCFGetSupportedReduction(scf::ForOp forOp, unsigned pos,
 }
 
 void SCFGetSupportedReductions(
-    scf::ForOp forOp, SmallVectorImpl<LoopReduction> &supportedReductions) {
-  unsigned numIterArgs = forOp.getNumIterOperands();
+    scf::ForOp forOp, SmallVectorImpl<affine::LoopReduction> &supportedReductions) {
+  unsigned numIterArgs = forOp.getNumRegionIterArgs();
   if (numIterArgs == 0)
     return;
   supportedReductions.reserve(numIterArgs);
   for (unsigned i = 0; i < numIterArgs; ++i) {
-    AtomicRMWKind kind;
+    arith::AtomicRMWKind kind;
     if (Value value = SCFGetSupportedReduction(forOp, i, kind))
-      supportedReductions.emplace_back(LoopReduction{kind, i, value});
+      supportedReductions.emplace_back(affine::LoopReduction{kind, i, value});
   }
 }
 
 bool isLoopParallel(scf::ForOp forOp) {
-  SmallVector<LoopReduction> parallelReductions;
+  SmallVector<affine::LoopReduction> parallelReductions;
   SCFGetSupportedReductions(forOp, parallelReductions);
-  return forOp.getNumIterOperands() == parallelReductions.size();
+  return forOp.getNumRegionIterArgs() == parallelReductions.size();
 }
 
 bool isIntOrIntTensor(Type typ) {
@@ -147,17 +151,17 @@ cloneBasicBlock(llvm::iterator_range<Region::OpIterator> bbOps,
   return newRegionOps;
 }
 
-FuncOp copyFunctionDeclaration(FuncOp funcOp, llvm::StringRef funcName,
+func::FuncOp copyFunctionDeclaration(func::FuncOp funcOp, llvm::StringRef funcName,
                                OpBuilder &rewriter) {
   PatternRewriter::InsertionGuard insertGuard(rewriter);
   rewriter.setInsertionPointAfter(funcOp);
-  auto newOp = cast<FuncOp>(rewriter.clone(*funcOp));
+  auto newOp = cast<func::FuncOp>(rewriter.clone(*funcOp));
 
   newOp.setName(funcName);
   return newOp;
 }
 
-FuncOp differentiateFunction(FuncOp funcOp, LAGradContext &ctx,
+func::FuncOp differentiateFunction(func::FuncOp funcOp, LAGradContext &ctx,
                              ArrayAttr gradientsOf,
                              ConversionPatternRewriter &rewriter,
                              bool topLevel = false, bool oneHotSparse = false) {
@@ -168,17 +172,17 @@ FuncOp differentiateFunction(FuncOp funcOp, LAGradContext &ctx,
   }
 
   // Need to double check the return type.
-  assert(funcOp.getType().getNumResults() == 1 &&
+  assert(funcOp.getFunctionType().getNumResults() == 1 &&
          "differentiating functions with more than one result not supported");
   if (!topLevel) {
-    Type gradSignalType = funcOp.getType().getResult(0);
+    Type gradSignalType = funcOp.getFunctionType().getResult(0);
     if (oneHotSparse && gradSignalType.isa<RankedTensorType>()) {
       auto tensorType = gradSignalType.cast<RankedTensorType>();
       gradSignalType = RankedTensorType::get(
           tensorType.getShape(), tensorType.getElementType(),
           StringAttr::get(rewriter.getContext(), "onehot"));
     }
-    funcOp.insertArgument(funcOp.getNumArguments(), gradSignalType, {});
+    funcOp.insertArgument(funcOp.getNumArguments(), gradSignalType, DictionaryAttr(), funcOp.getLoc());
   }
 
   std::vector<Operation *> ops;
@@ -191,7 +195,7 @@ FuncOp differentiateFunction(FuncOp funcOp, LAGradContext &ctx,
   PatternRewriter::InsertionGuard insertGuard(rewriter);
   for (auto it = ops.rbegin(); it != ops.rend(); it++) {
     Operation *op = *it;
-    if (isa<ReturnOp>(op)) {
+    if (isa<func::ReturnOp>(op)) {
       // This is the exit point
       rewriter.setInsertionPoint(op);
       assert(op->getNumOperands() == 1 &&
@@ -212,9 +216,9 @@ FuncOp differentiateFunction(FuncOp funcOp, LAGradContext &ctx,
     }
   }
 
-  auto fntyp = funcOp.getType();
-  SmallVector<Type> returnType(funcOp.getType().getNumInputs());
-  SmallVector<Value> returnValue(funcOp.getType().getNumInputs());
+  auto fntyp = funcOp.getFunctionType();
+  SmallVector<Type> returnType(funcOp.getFunctionType().getNumInputs());
+  SmallVector<Value> returnValue(funcOp.getFunctionType().getNumInputs());
   if (gradientsOf) {
     returnType.resize(gradientsOf.size());
     returnValue.resize(gradientsOf.size());
@@ -243,7 +247,7 @@ FuncOp differentiateFunction(FuncOp funcOp, LAGradContext &ctx,
   }
   funcOp.setType(
       FunctionType::get(funcOp.getContext(), fntyp.getInputs(), returnType));
-  rewriter.create<mlir::ReturnOp>(region->getLoc(), returnValue);
+  rewriter.create<mlir::func::ReturnOp>(region->getLoc(), returnValue);
   return funcOp;
 }
 
@@ -265,14 +269,14 @@ Value onesLike(LAGradContext &ctx, Location loc, Value operand,
       if (shapedType.getNumDynamicDims() > 0) {
         assert(ctx.dynamic_shapes.count(operand) &&
                "onesLike: operand was not found in dynamic shape map");
-        space = builder.create<linalg::InitTensorOp>(
+        space = builder.create<tensor::EmptyOp>(
             loc, ctx.dynamic_shapes.lookup(operand),
             shapedType.getElementType());
       } else {
-        space = builder.create<linalg::InitTensorOp>(
+        space = builder.create<tensor::EmptyOp>(
             loc, shapedType.getShape(), shapedType.getElementType());
       }
-      auto filled = builder.create<linalg::FillOp>(loc, one, space);
+      auto filled = builder.create<linalg::FillOp>(loc, ValueRange{one}, ValueRange{space});
       return filled.getResult(0);
     }
     assert(shapedType.getNumDynamicDims() == 0 &&
@@ -311,13 +315,13 @@ Value getZero(Location loc, Value operand, OpBuilder &rewriter, bool init) {
         }
       }
       // init_tensor ops don't support encodings out of the box.
-      Value space = rewriter.create<linalg::InitTensorOp>(
+      Value space = rewriter.create<tensor::EmptyOp>(
           loc, shape, shapedType.getElementType());
       if (shapedType.getEncoding()) {
         space = rewriter.create<lagrad::PackOp>(loc, shapedType, space);
         // space = rewriter.create<tensor::CastOp>(loc, shapedType, space);
       }
-      auto filled = rewriter.create<linalg::FillOp>(loc, zero, space);
+      auto filled = rewriter.create<linalg::FillOp>(loc, ValueRange{zero}, ValueRange{space});
       return filled.getResult(0);
     } else {
       // Will automatically be broadcasted to the right shape.
@@ -389,11 +393,11 @@ void collectFreeVars(Block *parentBlock, Region &region, ValueSet &out) {
 // This is definitely a bandaid behind an explosion of complexity in the
 // autodiff method.
 void eraseUnusedCalls(ModuleOp moduleOp, PatternRewriter &rewriter) {
-  moduleOp.walk([&](CallOp callOp) {
-    if (callOp.calleeAttr().getValue().startswith("__grad") &&
+  moduleOp.walk([&](func::CallOp callOp) {
+    if (callOp.getCalleeAttr().getValue().starts_with("__grad") &&
         callOp.use_empty()) {
       // rewriter.eraseOp(callOp);
-      // llvm::outs() << "saw callOp " << callOp.calleeAttr().getValue()
+      // llvm::outs() << "saw callOp " << callOp.getCalleeAttr().value()
       //              << " with " << callOp.use_empty() << " uses\n";
     }
   });
@@ -413,9 +417,9 @@ Value reverseBatchMatmul(linalg::BatchMatmulOp op, Value operand,
                     : SmallVector<AffineMap, 6>{idMap.getSubMap({0, 2, 1}),
                                                 idMap.getSubMap({0, 2, 3}),
                                                 idMap.getSubMap({0, 1, 3})};
-  SmallVector<StringRef, 6> iteratorTypes(
-      {getParallelIteratorTypeName(), getParallelIteratorTypeName(),
-       getReductionIteratorTypeName(), getParallelIteratorTypeName()});
+  SmallVector<utils::IteratorType, 6> iteratorTypes(
+      {utils::IteratorType::parallel, utils::IteratorType::parallel,
+       utils::IteratorType::reduction, utils::IteratorType::parallel});
   auto inputs = op_index == 0
                     ? SmallVector<Value, 2>{vjp_value, op.getOperand(1)}
                     : SmallVector<Value, 2>{op.getOperand(0), vjp_value};
@@ -443,7 +447,7 @@ Value addInPlace(Value source, Value dest, OpBuilder &builder) {
   auto rank = outputShape.getRank();
   SmallVector<AffineMap, 2> indexingMaps(2,
                                          builder.getMultiDimIdentityMap(rank));
-  SmallVector<StringRef, 1> iteratorTypes(rank, getParallelIteratorTypeName());
+  SmallVector<utils::IteratorType, 1> iteratorTypes(rank, utils::IteratorType::parallel);
   auto addOp = builder.create<linalg::GenericOp>(
       dest.getLoc(),
       /*resultTensorType=*/outputShape,
@@ -492,8 +496,8 @@ void populateVJP(Operation *op, LAGradContext &ctx,
 
     // Collect the free variables in the then block of the if op
     llvm::SmallDenseSet<Value> freeOperands;
-    collectFreeVars(ifOp.thenBlock(), ifOp.thenRegion(), freeOperands);
-    collectFreeVars(ifOp.elseBlock(), ifOp.elseRegion(), freeOperands);
+    collectFreeVars(ifOp.thenBlock(), ifOp.getThenRegion(), freeOperands);
+    collectFreeVars(ifOp.elseBlock(), ifOp.getElseRegion(), freeOperands);
 
     for (auto freeOperand : freeOperands) {
       auto result =
@@ -520,10 +524,10 @@ void populateVJP(Operation *op, LAGradContext &ctx,
 
     Value result = forOp.getResult(result_idx);
     auto vjp_value = env[result];
-    env[forOp.getIterOperands()[result_idx]] = env[result];
+    env[forOp.getInitArgs()[result_idx]] = env[result];
     assert(vjp_value && "vjp value for scf.for op was not found");
     ValueSet freeOperands;
-    collectFreeVars(forOp.getBody(), forOp.getLoopBody(), freeOperands);
+    collectFreeVars(forOp.getBody(), forOp.getRegion(), freeOperands);
 
     SmallVector<Value> free_operand_vec;
     for (auto v : freeOperands) {
@@ -581,17 +585,17 @@ void populateVJP(Operation *op, LAGradContext &ctx,
       }
     } else if (isa<arith::NegFOp>(op)) {
       vjp_value = rewriter.create<arith::NegFOp>(op->getLoc(), vjp_value);
-    } else if (auto selectOp = dyn_cast<mlir::SelectOp>(op)) {
+    } else if (auto selectOp = dyn_cast<mlir::arith::SelectOp>(op)) {
       if (op_index == 1) {
         // true branch
         auto zero = getZero(op->getLoc(), operand, rewriter);
-        vjp_value = rewriter.create<SelectOp>(
-            op->getLoc(), selectOp.condition(), vjp_value, zero);
+        vjp_value = rewriter.create<arith::SelectOp>(
+            op->getLoc(), selectOp.getCondition(), vjp_value, zero);
       } else if (op_index == 2) {
         // false branch
         auto zero = getZero(op->getLoc(), operand, rewriter);
-        vjp_value = rewriter.create<SelectOp>(
-            op->getLoc(), selectOp.condition(), zero, vjp_value);
+        vjp_value = rewriter.create<arith::SelectOp>(
+            op->getLoc(), selectOp.getCondition(), zero, vjp_value);
       }
     } else if (auto expOp = dyn_cast<math::ExpOp>(op)) {
       vjp_value = rewriter.create<arith::MulFOp>(expOp.getLoc(), vjp_value,
@@ -634,11 +638,11 @@ void populateVJP(Operation *op, LAGradContext &ctx,
       auto loc = op->getLoc();
       auto one = onesLike(ctx, loc, operand, rewriter);
       vjp_value = rewriter.create<arith::MulFOp>(
-          loc, powFOp.rhs(),
+          loc, powFOp.getRhs(),
           rewriter.create<math::PowFOp>(
-              loc, powFOp.lhs(),
-              rewriter.create<arith::SubFOp>(loc, powFOp.rhs(), one)));
-    } else if (auto callOp = dyn_cast<CallOp>(op)) {
+              loc, powFOp.getLhs(),
+              rewriter.create<arith::SubFOp>(loc, powFOp.getRhs(), one)));
+    } else if (auto callOp = dyn_cast<func::CallOp>(op)) {
       if (!isFloatOrFloatTensor(operand.getType())) {
         continue;
       }
@@ -654,27 +658,27 @@ void populateVJP(Operation *op, LAGradContext &ctx,
       Value new_val = vjp_value;
       if (requires_add) {
         auto before = rewriter.create<tensor::ExtractOp>(op->getLoc(), space,
-                                                         extractOp.indices());
+                                                         extractOp.getIndices());
         new_val =
             rewriter.create<arith::AddFOp>(op->getLoc(), before, vjp_value);
       }
       env[operand] = rewriter.create<tensor::InsertOp>(
-          op->getLoc(), new_val, space, extractOp.indices());
+          op->getLoc(), new_val, space, extractOp.getIndices());
       continue;
     } else if (auto insertOp = dyn_cast<tensor::InsertOp>(op)) {
       if (op_index > 0) {
         continue;
       }
       vjp_value = rewriter.create<tensor::ExtractOp>(op->getLoc(), vjp_value,
-                                                     insertOp.indices());
+                                                     insertOp.getIndices());
 
       // The destination is effectively the same memory location as the result.
-      auto zero = getZero(insertOp.getLoc(), insertOp.scalar(), rewriter);
+      auto zero = getZero(insertOp.getLoc(), insertOp.getScalar(), rewriter);
       auto new_dresult = rewriter.create<tensor::InsertOp>(
-          insertOp.getLoc(), zero, env[insertOp.result()], insertOp.indices());
-      env[insertOp.dest()] = new_dresult;
-      env[insertOp.result()] = new_dresult;
-      // env[insertOp.dest()] = env[insertOp.result()];
+          insertOp.getLoc(), zero, env[insertOp.getResult()], insertOp.getIndices());
+      env[insertOp.getDest()] = new_dresult;
+      env[insertOp.getResult()] = new_dresult;
+      // env[insertOp.getDest()] = env[insertOp.getResult()];
     } else if (auto extractSliceOp = dyn_cast<tensor::ExtractSliceOp>(op)) {
       auto resultType =
           extractSliceOp.getResult().getType().cast<RankedTensorType>();
@@ -694,9 +698,9 @@ void populateVJP(Operation *op, LAGradContext &ctx,
       }
       env[operand] = rewriter.create<tensor::InsertSliceOp>(
           operand.getLoc(), operand.getType(), new_value, space,
-          extractSliceOp.offsets(), extractSliceOp.sizes(),
-          extractSliceOp.strides(), extractSliceOp.static_offsets(),
-          extractSliceOp.static_sizes(), extractSliceOp.static_strides());
+          extractSliceOp.getOffsets(), extractSliceOp.getSizes(),
+          extractSliceOp.getStrides(), extractSliceOp.getStaticOffsets(),
+          extractSliceOp.getStaticSizes(), extractSliceOp.getStaticStrides());
       continue;
     } else if (auto insertSliceOp = dyn_cast<tensor::InsertSliceOp>(op)) {
       if (op_index > 0) {
@@ -706,16 +710,16 @@ void populateVJP(Operation *op, LAGradContext &ctx,
           op->getLoc(), insertSliceOp.getSourceType(), vjp_value,
           insertSliceOp.getMixedOffsets(), insertSliceOp.getMixedSizes(),
           insertSliceOp.getMixedStrides());
-      auto zero = getZero(op->getLoc(), insertSliceOp.source(), rewriter);
+      auto zero = getZero(op->getLoc(), insertSliceOp.getSource(), rewriter);
       auto destGrad = rewriter.create<tensor::InsertSliceOp>(
           op->getLoc(), zero, env[insertSliceOp.getResult()],
           insertSliceOp.getMixedOffsets(), insertSliceOp.getMixedSizes(),
           insertSliceOp.getMixedStrides());
-      env[insertSliceOp.dest()] = destGrad;
+      env[insertSliceOp.getDest()] = destGrad;
 
-      // env[insertSliceOp.dest()] = env[insertSliceOp.getResult()];
+      // env[insertSliceOp.getDest()] = env[insertSliceOp.getResult()];
     } else if (auto genericOp = dyn_cast<linalg::GenericOp>(op)) {
-      if (op_index > static_cast<size_t>(genericOp.getNumInputs() - 1))
+      if (op_index > static_cast<size_t>(genericOp.getNumDpsInputs() - 1))
         continue;
 
       // Additionally compute adjoints for all free variables. We only want
@@ -723,8 +727,8 @@ void populateVJP(Operation *op, LAGradContext &ctx,
       if (op_index == 0) {
         // Also update the output gradients
         for (auto it :
-             llvm::zip(genericOp.getOutputOperands(), genericOp.getResults())) {
-          env[std::get<0>(it)->get()] = env[std::get<1>(it)];
+             llvm::zip(genericOp.getDpsInits(), genericOp.getResults())) {
+          env[std::get<0>(it)] = env[std::get<1>(it)];
         }
         llvm::SmallDenseSet<Value> freeOperands;
         collectFreeVars(genericOp.getBody(), genericOp.getBodyRegion(),
@@ -783,7 +787,7 @@ void populateVJP(Operation *op, LAGradContext &ctx,
           ValueRange({vjp_value, op->getOperand(1 - op_index)}),
           /*outputs=*/ValueRange({output}), indexing_maps,
           /*iteratorTypes=*/
-          SmallVector<StringRef>({getParallelIteratorTypeName()}),
+          SmallVector<utils::IteratorType>({utils::IteratorType::parallel}),
           /*doc=*/"Copy and scalar multiplication",
           /*library call=*/library_call,
           [&](OpBuilder &builder, Location loc, ValueRange regionArgs) {
@@ -797,7 +801,7 @@ void populateVJP(Operation *op, LAGradContext &ctx,
         continue;
       if (op_index == 0) {
         // TODO: This is probably a bandaid solution.
-        env[matvecOp.getOutputOperand(0)->get()] = env[matvecOp.getResult(0)];
+        env[matvecOp.getDpsInitOperand(0)->get()] = env[matvecOp.getResult(0)];
         // Broadcast the gradient signal
         assert(operand.getType().isa<RankedTensorType>() &&
                "matvec input was not a ranked tensor type");
@@ -806,8 +810,8 @@ void populateVJP(Operation *op, LAGradContext &ctx,
         indexingMaps[0] = indexingMaps[0].getSubMap({0});
         indexingMaps[1] = indexingMaps[1].getSubMap({1});
         auto opType = operand.getType().dyn_cast<RankedTensorType>();
-        SmallVector<StringRef, 6> iteratorTypes(opType.getRank(),
-                                                getParallelIteratorTypeName());
+        SmallVector<utils::IteratorType, 6> iteratorTypes(opType.getRank(),
+                                                utils::IteratorType::parallel);
         auto outerProductOp = rewriter.create<linalg::GenericOp>(
             operand.getLoc(),
             /*resultTensorTypes=*/opType,
@@ -834,8 +838,8 @@ void populateVJP(Operation *op, LAGradContext &ctx,
             op->getNumOperands(), rewriter.getMultiDimIdentityMap(2));
         indexingMaps[0] = indexingMaps[0].getSubMap({0});
         indexingMaps[2] = indexingMaps[2].getSubMap({1});
-        SmallVector<StringRef, 6> iteratorTypes(
-            {getReductionIteratorTypeName(), getParallelIteratorTypeName()});
+        SmallVector<utils::IteratorType, 6> iteratorTypes(
+            {utils::IteratorType::reduction, utils::IteratorType::parallel});
 
         // TODO: This currently uses the allocated gradient space and adds
         // it inside the matmul. This may produce incorrect results due to
@@ -869,8 +873,8 @@ void populateVJP(Operation *op, LAGradContext &ctx,
             op->getNumOperands(), rewriter.getMultiDimIdentityMap(2));
         indexingMaps[1] = indexingMaps[1].getSubMap({1});
         indexingMaps[2] = indexingMaps[2].getSubMap({0});
-        SmallVector<StringRef, 6> iteratorTypes(
-            {getParallelIteratorTypeName(), getReductionIteratorTypeName()});
+        SmallVector<utils::IteratorType, 6> iteratorTypes(
+            {utils::IteratorType::parallel, utils::IteratorType::reduction});
         auto matmulOp = rewriter.create<linalg::GenericOp>(
             operand.getLoc(),
             /*resultTensorTypes=*/operand.getType(),
@@ -897,8 +901,8 @@ void populateVJP(Operation *op, LAGradContext &ctx,
         indexingMaps[0] = indexingMaps[0].getSubMap({1});
         indexingMaps[1] = indexingMaps[1].getSubMap({0});
         auto opType = operand.getType().dyn_cast<RankedTensorType>();
-        SmallVector<StringRef, 6> iteratorTypes(opType.getRank(),
-                                                getParallelIteratorTypeName());
+        SmallVector<utils::IteratorType, 6> iteratorTypes(opType.getRank(),
+                                                utils::IteratorType::parallel);
         auto outerProductOp = rewriter.create<linalg::GenericOp>(
             operand.getLoc(),
             /*resultTensorTypes=*/opType,
@@ -929,9 +933,9 @@ void populateVJP(Operation *op, LAGradContext &ctx,
         indexingMaps[1] = indexingMaps[1].getSubMap({1, 2});
         indexingMaps[2] = indexingMaps[2].getSubMap({0, 2});
       }
-      SmallVector<StringRef, 6> iteratorTypes({getParallelIteratorTypeName(),
-                                               getReductionIteratorTypeName(),
-                                               getParallelIteratorTypeName()});
+      SmallVector<utils::IteratorType, 6> iteratorTypes({utils::IteratorType::parallel,
+                                               utils::IteratorType::reduction,
+                                               utils::IteratorType::parallel});
       SmallVector<Value> inputs(2);
       if (op_index == 0) {
         inputs[0] = vjp_value;
@@ -974,18 +978,18 @@ void populateVJP(Operation *op, LAGradContext &ctx,
   }
 }
 
-Value reverseCallOp(CallOp op, LAGradContext &ctx, Value vjp_value,
+Value reverseCallOp(func::CallOp op, LAGradContext &ctx, Value vjp_value,
                     size_t op_index, ConversionPatternRewriter &rewriter) {
   auto *context = op.getContext();
   std::stringstream gradFuncStream;
-  gradFuncStream << "__grad_" << op.callee().str() << "_arg" << op_index;
+  gradFuncStream << "__grad_" << op.getCallee().str() << "_arg" << op_index;
   auto gradFuncName = gradFuncStream.str();
   assert(ctx.moduleOp && "moduleOp was null");
   auto dFuncOp =
-      dyn_cast_or_null<FuncOp>(ctx.moduleOp.lookupSymbol(gradFuncName));
+      dyn_cast_or_null<func::FuncOp>(ctx.moduleOp.lookupSymbol(gradFuncName));
   if (!dFuncOp) {
     auto primalFunc =
-        dyn_cast<FuncOp>(ctx.moduleOp.lookupSymbol(op.calleeAttr()));
+        dyn_cast<func::FuncOp>(ctx.moduleOp.lookupSymbol(op.getCalleeAttr()));
     dFuncOp = copyFunctionDeclaration(primalFunc, gradFuncName, rewriter);
 
     auto innerGradsOf = ArrayAttr::get(
@@ -997,7 +1001,7 @@ Value reverseCallOp(CallOp op, LAGradContext &ctx, Value vjp_value,
   llvm::SmallVector<Value> operands(op.getOperands());
   operands.push_back(vjp_value);
   auto adjointCall =
-      rewriter.create<mlir::CallOp>(op.getLoc(), dFuncOp, operands);
+      rewriter.create<mlir::func::CallOp>(op.getLoc(), dFuncOp, operands);
   assert(adjointCall.getNumResults() == 1 &&
          "expected adjoint call to produce 1 result");
   return adjointCall.getResult(0);

--- a/lib/LLFastMath/LLFastMath.cpp
+++ b/lib/LLFastMath/LLFastMath.cpp
@@ -9,21 +9,16 @@
 #include "llvm/IR/InstIterator.h"
 #include "llvm/IR/InstrTypes.h"
 #include "llvm/IR/Instruction.h"
-#include "llvm/IR/LegacyPassManager.h"
 #include "llvm/IR/Module.h"
-#include "llvm/Pass.h"
-#include "llvm/Support/CommandLine.h"
+#include "llvm/Passes/PassBuilder.h"
+#include "llvm/Passes/PassPlugin.h"
 #include "llvm/Support/raw_ostream.h"
-#include "llvm/Transforms/IPO/PassManagerBuilder.h"
 
 using namespace llvm;
 
 namespace {
-struct LLFastMathPass : public FunctionPass {
-  static char ID;
-  LLFastMathPass() : FunctionPass(ID) {}
-
-  virtual bool runOnFunction(Function &F) {
+struct LLFastMathPass : PassInfoMixin<LLFastMathPass> {
+  PreservedAnalyses run(Function &F, FunctionAnalysisManager &) {
     bool modified = false;
     for (inst_iterator I = inst_begin(F), E = inst_end(F); I != E; ++I) {
       if (isa<FPMathOperator>(*I)) {
@@ -31,17 +26,21 @@ struct LLFastMathPass : public FunctionPass {
         modified = true;
       }
     }
-    return modified;
+    return modified ? PreservedAnalyses::none() : PreservedAnalyses::all();
   }
 };
 } // namespace
 
-char LLFastMathPass::ID = 0;
-
-static RegisterPass<LLFastMathPass> LX("llfast-math", "");
-
-static RegisterStandardPasses LY(PassManagerBuilder::EP_EarlyAsPossible,
-                                 [](const PassManagerBuilder &Builder,
-                                    legacy::PassManagerBase &PM) {
-                                   PM.add(new LLFastMathPass());
-                                 });
+extern "C" LLVM_ATTRIBUTE_WEAK ::llvm::PassPluginLibraryInfo
+llvmGetPassPluginInfo() {
+  return {LLVM_PLUGIN_API_VERSION, "LLFastMath", LLVM_VERSION_STRING,
+          [](PassBuilder &PB) {
+            PB.registerOptimizerEarlyEPCallback(
+                [](ModulePassManager &MPM, OptimizationLevel,
+                   ThinOrFullLTOPhase) {
+                  FunctionPassManager FPM;
+                  FPM.addPass(LLFastMathPass());
+                  MPM.addPass(createModuleToFunctionPassAdaptor(std::move(FPM)));
+                });
+          }};
+}


### PR DESCRIPTION
LLVM 20.0.0git commit id `9f75b6664f1eaec1517f6cb620b34100b7b54857)`

**Key Fixes Applied**:
1. TableGen Files:
- OpTrait → Trait
- NoSideEffect → Pure
- verifier → hasVerifier
2. CMakeLists.txt:
- C++14 → C++17
3. Header Migrations:
- mlir/Dialect/StandardOps → mlir/Dialect/Func
- mlir/Dialect/Arithmetic → mlir/Dialect/Arith
- mlir/Dialect/SCF/SCF.h → mlir/Dialect/SCF/IR/SCF.h
- mlir/Dialect/Linalg/IR/LinalgOps.h → mlir/Dialect/Linalg/IR/Linalg.h
- Added missing includes for Bufferization, Math, MemRef, Tensor, Affine dialects
4. API Changes:
- BlockAndValueMapping → IRMapping
- OwningRewritePatternList → RewritePatternSet
- FuncOp → func::FuncOp, CallOp → func::CallOp, ReturnOp → func::ReturnOp
- LLVMPointerType::get(Type) → LLVMPointerType::get(context) (opaque pointers)
- LinalgOp DPS API: getNumInputs() → getNumDpsInputs(), getOutputOperands() → getDpsInits(), etc.
- memref::BufferCastOp → bufferization::ToMemrefOp
- memref::TensorLoadOp → bufferization::ToTensorOp
- linalg::CopyOp now requires ValueRange for inputs/outputs
- linalg::FillOp now requires ValueRange for inputs/outputs
- memref::CastOp and SubViewOp build signatures changed
- scf::IfOp build API changed (no longer takes builder lambdas)
- Block::getOps() → Block::getOperations() or Region::op_begin()/op_end()
- std::optional::getValue() → std::optional::value()
- Various attribute value() → getValue() methods
- getParallelIteratorTypeName() → utils::IteratorType::parallel
- getReductionIteratorTypeName() → utils::IteratorType::reduction
- ConversionPattern::matchAndRewrite signature changed to use OpAdaptor
- funcOp.getType() → funcOp.getFunctionType()
- funcOp.insertArgument() now requires a location parameter
- scf::ForOp::getTiedLoopResult() now requires a pointer
- applyPatternsAndFoldGreedily() signature changed
- PatternRewriter::updateRootInPlace() → modifyOpInPlace()
- StringRef::startswith() → starts_with()
- Range struct fields are now OpFoldResult instead of Value
- memref::SubViewOp static offsets/sizes/strides changed from ArrayAttr to DenseI64ArrayAttr
5. LLFastMath.cpp:
- Migrated from legacy pass manager to new pass manager API